### PR TITLE
Icon size set sm to size-3

### DIFF
--- a/components/stepper/step-icon.tsx
+++ b/components/stepper/step-icon.tsx
@@ -20,7 +20,7 @@ interface StepIconProps {
 const iconVariants = cva("", {
 	variants: {
 		size: {
-			sm: "size-4",
+			sm: "size-3",
 			md: "size-4",
 			lg: "size-5",
 		},


### PR DESCRIPTION
When using custom icon, showing the same size for sm and md seems weird. I propose to change the sm variant to smaller size