### PR TITLE
Fix data-completed

### DIFF
--- a/.changeset/late-otters-kick.md
+++ b/.changeset/late-otters-kick.md
@@ -1,0 +1,5 @@
+---
+"@stepperize/react": patch
+---
+
+Fix data-completed

--- a/packages/react/src/stepper.tsx
+++ b/packages/react/src/stepper.tsx
@@ -64,7 +64,7 @@ export const Stepper = <
 				"data-step": step.id,
 				"data-optional": step.isOptional ?? false,
 				"data-disabled": step.isDisabled ?? false,
-				"data-completed": currentStep.id > step.id,
+				"data-completed": counter > steps.findIndex(s => s.id === id),
 				"data-active": isActive,
 				"data-last": isLastStep,
 			},


### PR DESCRIPTION
`data-completed` should probably depend on the step index, not on its `id`