### PR TITLE
Fix stepper.when usage in use-stepper.mdx

### DIFF
--- a/.changeset/afraid-comics-fly.md
+++ b/.changeset/afraid-comics-fly.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Fix stepper.when usage in use-stepper.mdx

--- a/docs/pages/docs/getting-started/use-stepper.mdx
+++ b/docs/pages/docs/getting-started/use-stepper.mdx
@@ -71,7 +71,7 @@ const MyStepperComponent = () => {
         <p>This is the {step.title} step.</p>
       ))}
 
-      <p>{stepper.when("last", "Finished!", "Not yet...")}</p> // "Finished!" | "Not yet..."
+      <p>{stepper.when("last", () => "Finished!", () => "Not yet...")}</p> // "Finished!" | "Not yet..."
     </>
   )
 }


### PR DESCRIPTION
## Description
There was a syntax error in an example in the user-stepper.mdx, this fixes that so if you copy-paste it into your project it works.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation (if necessary).
- [x] I have checked the build and it works as expected.
