### PR TITLE
chore: set react minimum version >=17

### DIFF
--- a/.changeset/young-pianos-draw.md
+++ b/.changeset/young-pianos-draw.md
@@ -1,0 +1,5 @@
+---
+"@stepperize/react": major
+---
+
+Fix react version to work with v19

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,8 @@
 		"clean": "rm -rf .turbo && rm -rf node_modules dist"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0"
+		"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,10 @@ importers:
         version: 5.6.2
 
   packages/react:
+    dependencies:
+      react-dom:
+        specifier: ^17.0.0 || ^18.0.0 || ^19.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.0.0


### PR DESCRIPTION
## Description

- Update react packages version to work with latest React 19 (also support to work with NextJS 15)

## Related Issues

- https://github.com/damianricobelli/stepperize/issues/77

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation (if necessary).
- [x] I have checked the build and it works as expected.

## Screenshots (if appropriate)

N/A

## Additional Notes

With this changes [stepperize](https://github.com/damianricobelli/stepperize) package can be used with react versions: 17, 18 and 19.