### PR TITLE
Remove erroneous const assertion in Steps type declaration

### DIFF
--- a/packages/react/src/define-stepper.ts
+++ b/packages/react/src/define-stepper.ts
@@ -2,7 +2,7 @@ import type { Get, ScopedProps, Step, Stepper } from "./types";
 
 import * as React from "react";
 
-export const defineStepper = <const Steps extends Step[]>(...steps: Steps) => {
+export const defineStepper = <Steps extends Step[]>(...steps: Steps) => {
 	const Context = React.createContext(null as any as Stepper<Steps>);
 
 	const useStepper = (initialStep?: Get.Id<Steps>) => {


### PR DESCRIPTION
## Description

The const assertion in the Steps type declaration was removed to enhance type flexibility and align with TypeScript's intended behavior, resolving potential type inference issues.

## Related Issues

List any related issues, bugs, or feature requests that this pull request addresses.

- Issue: [#54](https://github.com/damianricobelli/stepperize/issues/54)

## Checklist

Please review the following checklist before submitting the pull request:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation (if necessary).
- [x] I have checked the build and it works as expected.

## Screenshots (if appropriate)

Include screenshots or videos to demonstrate the visual changes introduced by this pull request.

## Additional Notes

Provide any additional information that might be helpful for the reviewer, such as implementation details or potential issues.