### PR TITLE
feat: Added the ability to render steps conditionally depending on the result of a callback function

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -41,5 +41,10 @@ export type StepperReturn<Steps extends Step[]> = {
 	useStepper: (props?: {
 		initialStep?: Get.Id<Steps>;
 		initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+		/**
+		 * Optional callback that returns the list of step IDs to include at runtime.
+		 * Only steps whose IDs are returned here will be part of the stepper.
+		 */
+		stepFilter?: () => Get.Id<Steps>[];
 	}) => Stepper<Steps>;
 };


### PR DESCRIPTION


## Description

There are certain cases where we might want only some some steps of the form to be present to form the stepper.

For example, you might have a stepper with two schemas for `refunds` and `exchanges`. Now, it is possible that you only have `refunds` or `exchanges` or sometimes both, what do you do in that case? 

You can use a duct tape solution of toggling between steps using the `when` method as I described in this issue: https://github.com/damianricobelli/stepperize/issues/127

- What issue does this pull request address?
  https://github.com/damianricobelli/stepperize/issues/127

- What does it fix, improve, or add?

Now, you can add a callback function to have the stepper consist of only those steps which matter for the case. No need to duct tape it.
