### PR TITLE
fix: update import path for Button component in installation documentation

### DIFF
--- a/apps/docs/content/docs/react/shadcn/installation.mdx
+++ b/apps/docs/content/docs/react/shadcn/installation.mdx
@@ -30,7 +30,7 @@ Or install the component manually copying the following code in your project
     import * as React from "react";
 
     import { cn } from "@/lib/utils";
-    import { Button } from "@/registry/new-york/ui/button";
+    import { Button } from "@/components/ui/button";
 
     const StepperContext = React.createContext<Stepper.ConfigProps | null>(null);
 


### PR DESCRIPTION
## Description

This PR updates the import path in the installation documentation to use the standard shadcn-ui component organization pattern. The change replaces `@/registry/new-york/ui/button` with `@/components/ui/button` to align with the recommended project structure.

The change emphasizes that while shadcn-ui's repository uses `registry/ui/new-york` for component organization, the recommended approach for custom projects is to use `@/components/ui` for better maintainability and consistency.

## Related Issues

N/A - This appears to be a documentation improvement.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation.

## Additional Notes

This change helps maintain consistency with shadcn-ui's recommended project structure and makes the documentation more accurate for users implementing the stepper component in their projects.

The following sections were removed as they weren't applicable:
- Screenshots (no visual changes)
- Tests (documentation-only change)
- Build verification (documentation-only change)