### PR TITLE
fix: Add type="button" to shadcn docs

### DIFF
--- a/apps/docs/content/docs/react/shadcn/api.mdx
+++ b/apps/docs/content/docs/react/shadcn/api.mdx
@@ -191,6 +191,7 @@ export function MyFirstStepper() {
           <Stepper.Controls>
             {!methods.isLast && (
               <Button
+                type="button"
                 variant="secondary"
                 onClick={methods.prev}
                 disabled={methods.isFirst}


### PR DESCRIPTION
There is a [bug](https://github.com/damianricobelli/stepperize/issues/75) that breaks the back button when adding more than 2 steps to the shadcn example. I lost quite a bit off time on this so I'd like to prevent the same for future users. 

It just adds `type="button"` to the 'previous' button and it works for an arbitrary amount of steps.