### PR TITLE
feat: enhance stepper lifecycle with multiple callbacks and metadata

### DIFF
--- a/.changeset/sharp-trees-greet.md
+++ b/.changeset/sharp-trees-greet.md
@@ -1,0 +1,7 @@
+---
+"docs": patch
+"@stepperize/react": minor
+"@stepperize/core": minor
+---
+
+feat: enhance stepper lifecycle with multiple callbacks and metadata

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -7,13 +7,13 @@ import { Footer } from "@/components/home/footer";
 import Hero from "@/components/home/hero";
 
 export default function HomePage() {
-	return (
-		<div className="min-h-screen">
-			<Hero />
-			<Features />
-			<CodeExample>
-				<Code
-					code={`import * as React from "react";
+  return (
+    <div className="min-h-screen">
+      <Hero />
+      <Features />
+      <CodeExample>
+        <Code
+          code={`import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const stepper = defineStepper(
@@ -43,12 +43,12 @@ const StepperDemo = () => {
   );
 }
 `}
-					lang="tsx"
-				/>
-			</CodeExample>
-			<DemoSection />
-			<Cta />
-			<Footer />
-		</div>
-	);
+          lang="tsx"
+        />
+      </CodeExample>
+      <DemoSection />
+      <Cta />
+      <Footer />
+    </div>
+  );
 }

--- a/apps/docs/components/demos/basic-custom-indicator-preview.tsx
+++ b/apps/docs/components/demos/basic-custom-indicator-preview.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import { defineStepper } from "@stepperize/react";
 import { useStepItemContext } from "@stepperize/react/primitives";
+import React from "react";
 
 const { Stepper } = defineStepper(
   { id: "a", title: "First" },
@@ -37,19 +37,29 @@ export function BasicCustomIndicatorPreview() {
                       <Stepper.Indicator className="inline-flex size-4 items-center justify-center rounded-full bg-inherit text-xs font-semibold">
                         <StepNumber />
                       </Stepper.Indicator>
-                      <Stepper.Title render={(props) => <span {...props}>{step.title}</span>} />
+                      <Stepper.Title
+                        render={(props) => <span {...props}>{step.title}</span>}
+                      />
                     </Trigger>
                   </Stepper.Item>
                   {step.id !== "c" && (
-                    <span className="self-center text-gray-400 dark:text-gray-500">→</span>
+                    <span className="self-center text-gray-400 dark:text-gray-500">
+                      →
+                    </span>
                   )}
                 </React.Fragment>
               ))}
             </Stepper.List>
             <div className="mt-4 min-h-10 text-gray-900 dark:text-gray-100">
-              <Stepper.Content step="a"><p className="m-0">First step content</p></Stepper.Content>
-              <Stepper.Content step="b"><p className="m-0">Second step content</p></Stepper.Content>
-              <Stepper.Content step="c"><p className="m-0">Third step content</p></Stepper.Content>
+              <Stepper.Content step="a">
+                <p className="m-0">First step content</p>
+              </Stepper.Content>
+              <Stepper.Content step="b">
+                <p className="m-0">Second step content</p>
+              </Stepper.Content>
+              <Stepper.Content step="c">
+                <p className="m-0">Third step content</p>
+              </Stepper.Content>
             </div>
             <div className="mt-4 flex flex-wrap gap-2">
               {stepper.state.isLast ? (

--- a/apps/docs/components/demos/basic-horizontal-preview.tsx
+++ b/apps/docs/components/demos/basic-horizontal-preview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import { defineStepper } from "@stepperize/react";
+import React from "react";
 
 const { Stepper } = defineStepper(
   { id: "account", title: "Account" },
@@ -28,19 +28,29 @@ export function BasicHorizontalPreview() {
                 <React.Fragment key={step.id}>
                   <Stepper.Item step={step.id}>
                     <Trigger>
-                      <Stepper.Title render={(props) => <span {...props}>{step.title}</span>} />
+                      <Stepper.Title
+                        render={(props) => <span {...props}>{step.title}</span>}
+                      />
                     </Trigger>
                   </Stepper.Item>
                   {step.id !== "done" && (
-                    <span className="self-center text-gray-400 dark:text-gray-500">→</span>
+                    <span className="self-center text-gray-400 dark:text-gray-500">
+                      →
+                    </span>
                   )}
                 </React.Fragment>
               ))}
             </Stepper.List>
             <div className="mt-4 min-h-12 text-gray-900 dark:text-gray-100">
-              <Stepper.Content step="account"><p className="m-0">Account form</p></Stepper.Content>
-              <Stepper.Content step="profile"><p className="m-0">Profile form</p></Stepper.Content>
-              <Stepper.Content step="done"><p className="m-0">All done!</p></Stepper.Content>
+              <Stepper.Content step="account">
+                <p className="m-0">Account form</p>
+              </Stepper.Content>
+              <Stepper.Content step="profile">
+                <p className="m-0">Profile form</p>
+              </Stepper.Content>
+              <Stepper.Content step="done">
+                <p className="m-0">All done!</p>
+              </Stepper.Content>
             </div>
             <div className="mt-4 flex flex-wrap gap-2">
               {stepper.state.isLast ? (

--- a/apps/docs/components/demos/basic-vertical-preview.tsx
+++ b/apps/docs/components/demos/basic-vertical-preview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import { defineStepper } from "@stepperize/react";
+import React from "react";
 
 const { Stepper } = defineStepper(
   { id: "one", title: "Step 1" },
@@ -35,7 +35,9 @@ export function BasicVerticalPreview() {
                 <React.Fragment key={step.id}>
                   <Stepper.Item step={step.id}>
                     <Trigger>
-                      <Stepper.Title render={(props) => <span {...props}>{step.title}</span>} />
+                      <Stepper.Title
+                        render={(props) => <span {...props}>{step.title}</span>}
+                      />
                     </Trigger>
                   </Stepper.Item>
                   {index < stepper.state.all.length - 1 && <VerticalLine />}

--- a/apps/docs/components/demos/first-stepper-preview.tsx
+++ b/apps/docs/components/demos/first-stepper-preview.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(

--- a/apps/docs/components/demos/multi-scoped-preview.tsx
+++ b/apps/docs/components/demos/multi-scoped-preview.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const GlobalStepper = defineStepper(

--- a/apps/docs/components/demos/scoped-preview.tsx
+++ b/apps/docs/components/demos/scoped-preview.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(

--- a/apps/docs/components/home/demo-section.tsx
+++ b/apps/docs/components/home/demo-section.tsx
@@ -1,151 +1,167 @@
 "use client";
 
-import { cn } from "@/lib/cn";
 import { defineStepper } from "@stepperize/react";
 import { CheckCircle, CreditCard, Home, User } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import * as React from "react";
+import React from "react";
+import { cn } from "@/lib/cn";
 
 const stepper = defineStepper(
-	{ id: "personal-info", label: "Personal Info", icon: User },
-	{ id: "address", label: "Address", icon: Home },
-	{ id: "payment", label: "Payment", icon: CreditCard },
-	{ id: "success", label: "Done", icon: CheckCircle }
+  { id: "personal-info", label: "Personal Info", icon: User },
+  { id: "address", label: "Address", icon: Home },
+  { id: "payment", label: "Payment", icon: CreditCard },
+  { id: "success", label: "Done", icon: CheckCircle },
 );
 
 const slideVariants = {
-	enter: { opacity: 0 },
-	center: { opacity: 1 },
-	exit: { opacity: 0 },
+  enter: { opacity: 0 },
+  center: { opacity: 1 },
+  exit: { opacity: 0 },
 };
 
 export const DemoSection = ({ className }: { className?: string }) => {
-	return (
-		<stepper.Scoped>
-			<section id="demo" className={cn("px-4 sm:px-6 lg:px-8 py-20", className)}>
-				<DemoContent />
-			</section>
-		</stepper.Scoped>
-	);
+  return (
+    <stepper.Scoped>
+      <section
+        id="demo"
+        className={cn("px-4 sm:px-6 lg:px-8 py-20", className)}
+      >
+        <DemoContent />
+      </section>
+    </stepper.Scoped>
+  );
 };
 
 // #region DemoContent
 
 const DemoContent = () => {
-	const methods = stepper.useStepper();
+  const methods = stepper.useStepper();
 
-	const [formData, setFormData] = React.useState({
-		firstName: "",
-		lastName: "",
-		email: "",
-		address: "",
-		city: "",
-		zipCode: "",
-		cardName: "",
-		cardNumber: "",
-		expiry: "",
-		cvv: "",
-	});
+  const [formData, setFormData] = React.useState({
+    firstName: "",
+    lastName: "",
+    email: "",
+    address: "",
+    city: "",
+    zipCode: "",
+    cardName: "",
+    cardNumber: "",
+    expiry: "",
+    cvv: "",
+  });
 
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const { name, value } = e.target;
-		setFormData((prev) => ({ ...prev, [name]: value }));
-	};
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
 
-	const handleSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
-		if (!methods.state.isLast) {
-			methods.navigation.next();
-		}
-	};
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!methods.state.isLast) {
+      methods.navigation.next();
+    }
+  };
 
-	const isComplete = methods.state.isLast;
+  const isComplete = methods.state.isLast;
 
-	return (
-		<div className="max-w-2xl mx-auto">
-			<h2 className="text-2xl font-semibold text-gray-12 mb-2 text-center">See it in action</h2>
-			<p className="text-gray-11 text-center mb-10 text-sm">Multi-step form with @stepperize/react</p>
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h2 className="text-2xl font-semibold text-gray-12 mb-2 text-center">
+        See it in action
+      </h2>
+      <p className="text-gray-11 text-center mb-10 text-sm">
+        Multi-step form with @stepperize/react
+      </p>
 
-			<div className="border border-gray-6 rounded-xl overflow-hidden bg-gray-2/30">
-				<StepperHeader methods={methods} isComplete={isComplete} />
-				<div className="p-6">
-					<form onSubmit={handleSubmit}>
-						<AnimatePresence mode="wait">
-							{methods.flow.when("personal-info", () => (
-								<motion.div
-									key="step1"
-									variants={slideVariants}
-									initial="enter"
-									animate="center"
-									exit="exit"
-									transition={{ duration: 0.15 }}
-								>
-									<PersonalInfoStep formData={formData} handleChange={handleChange} />
-								</motion.div>
-							))}
-							{methods.flow.when("address", () => (
-								<motion.div
-									key="step2"
-									variants={slideVariants}
-									initial="enter"
-									animate="center"
-									exit="exit"
-									transition={{ duration: 0.15 }}
-								>
-									<AddressStep formData={formData} handleChange={handleChange} />
-								</motion.div>
-							))}
-							{methods.flow.when("payment", () => (
-								<motion.div
-									key="step3"
-									variants={slideVariants}
-									initial="enter"
-									animate="center"
-									exit="exit"
-									transition={{ duration: 0.15 }}
-								>
-									<PaymentStep formData={formData} handleChange={handleChange} />
-								</motion.div>
-							))}
-							{methods.flow.when("success", () => (
-								<motion.div
-									key="step4"
-									variants={slideVariants}
-									initial="enter"
-									animate="center"
-									exit="exit"
-									transition={{ duration: 0.15 }}
-								>
-									<CompletionScreen
-										onReset={() => {
-											methods.navigation.reset();
-										}}
-									/>
-								</motion.div>
-							))}
-						</AnimatePresence>
-						<div className="mt-6 flex justify-between">
-							{!methods.state.isFirst && (
-								<button
-									type="button"
-									onClick={() => methods.navigation.prev()}
-									className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-7 text-gray-12 hover:bg-gray-4 transition-colors"
-								>
-									Back
-								</button>
-							)}
-							<button
-								type="submit"
-								className="ml-auto px-4 py-2 text-sm font-medium rounded-lg text-white bg-indigo-9 hover:bg-indigo-10 transition-colors"
-							>
-								{isComplete ? "Submit" : "Next"}
-							</button>
-						</div>
-					</form>
-				</div>
-			</div>
-		</div>
-	);
+      <div className="border border-gray-6 rounded-xl overflow-hidden bg-gray-2/30">
+        <StepperHeader methods={methods} isComplete={isComplete} />
+        <div className="p-6">
+          <form onSubmit={handleSubmit}>
+            <AnimatePresence mode="wait">
+              {methods.flow.when("personal-info", () => (
+                <motion.div
+                  key="step1"
+                  variants={slideVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: 0.15 }}
+                >
+                  <PersonalInfoStep
+                    formData={formData}
+                    handleChange={handleChange}
+                  />
+                </motion.div>
+              ))}
+              {methods.flow.when("address", () => (
+                <motion.div
+                  key="step2"
+                  variants={slideVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: 0.15 }}
+                >
+                  <AddressStep
+                    formData={formData}
+                    handleChange={handleChange}
+                  />
+                </motion.div>
+              ))}
+              {methods.flow.when("payment", () => (
+                <motion.div
+                  key="step3"
+                  variants={slideVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: 0.15 }}
+                >
+                  <PaymentStep
+                    formData={formData}
+                    handleChange={handleChange}
+                  />
+                </motion.div>
+              ))}
+              {methods.flow.when("success", () => (
+                <motion.div
+                  key="step4"
+                  variants={slideVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: 0.15 }}
+                >
+                  <CompletionScreen
+                    onReset={() => {
+                      methods.navigation.reset();
+                    }}
+                  />
+                </motion.div>
+              ))}
+            </AnimatePresence>
+            <div className="mt-6 flex justify-between">
+              {!methods.state.isFirst && (
+                <button
+                  type="button"
+                  onClick={() => methods.navigation.prev()}
+                  className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-7 text-gray-12 hover:bg-gray-4 transition-colors"
+                >
+                  Back
+                </button>
+              )}
+              <button
+                type="submit"
+                className="ml-auto px-4 py-2 text-sm font-medium rounded-lg text-white bg-indigo-9 hover:bg-indigo-10 transition-colors"
+              >
+                {isComplete ? "Submit" : "Next"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 // #endregion DemoContent
@@ -153,37 +169,40 @@ const DemoContent = () => {
 // #region InputField
 
 const InputField = ({
-	label,
-	name,
-	type = "text",
-	value,
-	onChange,
-	placeholder,
-	required = false,
+  label,
+  name,
+  type = "text",
+  value,
+  onChange,
+  placeholder,
+  required = false,
 }: {
-	label: string;
-	name: string;
-	type?: string;
-	value: string;
-	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-	placeholder?: string;
-	required?: boolean;
+  label: string;
+  name: string;
+  type?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  required?: boolean;
 }) => (
-	<div>
-		<label htmlFor={name} className="block text-sm font-medium text-gray-12 mb-1">
-			{label}
-		</label>
-		<input
-			type={type}
-			name={name}
-			id={name}
-			value={value}
-			onChange={onChange}
-			placeholder={placeholder}
-			required={required}
-			className="w-full px-3 py-2 text-sm bg-gray-2 border border-gray-6 rounded-lg text-gray-12 placeholder:text-gray-9 focus:outline-none focus:ring-2 focus:ring-indigo-8 focus:border-indigo-8"
-		/>
-	</div>
+  <div>
+    <label
+      htmlFor={name}
+      className="block text-sm font-medium text-gray-12 mb-1"
+    >
+      {label}
+    </label>
+    <input
+      type={type}
+      name={name}
+      id={name}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      required={required}
+      className="w-full px-3 py-2 text-sm bg-gray-2 border border-gray-6 rounded-lg text-gray-12 placeholder:text-gray-9 focus:outline-none focus:ring-2 focus:ring-indigo-8 focus:border-indigo-8"
+    />
+  </div>
 );
 
 // #endregion InputField
@@ -191,70 +210,70 @@ const InputField = ({
 // #region StepperHeader
 
 const StepperHeader = ({
-	methods,
-	isComplete,
+  methods,
+  isComplete,
 }: {
-	methods: ReturnType<typeof stepper.useStepper>;
-	isComplete: boolean;
+  methods: ReturnType<typeof stepper.useStepper>;
+  isComplete: boolean;
 }) => {
-	const steps = methods.state.all;
-	const currentIndex = methods.state.current.index;
-	const progress =
-		methods.state.current.data.id === steps[steps.length - 1].id || isComplete
-			? "100%"
-			: `${(currentIndex / (steps.length - 1)) * 100}%`;
+  const steps = methods.state.all;
+  const currentIndex = methods.state.current.index;
+  const progress =
+    methods.state.current.data.id === steps[steps.length - 1].id || isComplete
+      ? "100%"
+      : `${(currentIndex / (steps.length - 1)) * 100}%`;
 
-	return (
-		<nav className="bg-gray-3/50 border-b border-gray-6 px-4 py-5">
-			<ol className="flex justify-between items-center relative">
-				{/* Line from center of first step to center of last step (4 steps = 12.5% / 87.5%) */}
-				<div className="absolute top-5 left-[12.5%] right-[12.5%] h-0.5 bg-gray-6 z-0 rounded-full">
-					<div
-						className="h-full bg-indigo-9 rounded-full transition-all duration-300"
-						style={{ width: progress }}
-					/>
-				</div>
-				{steps.map((step, index) => {
-					const isActive = step.id === methods.state.current.data.id;
-					const isPast = index < currentIndex;
-					return (
-						<li
-							key={step.id}
-							className="flex flex-col items-center relative z-10 flex-1"
-						>
-							<button
-								type="button"
-								onClick={() => !isComplete && methods.navigation.goTo(step.id)}
-								className={cn(
-									"size-9 rounded-full flex items-center justify-center transition-colors shrink-0",
-									isPast || (isComplete && index < steps.length - 1)
-										? "bg-indigo-9 text-white"
-										: isActive || (isComplete && index === steps.length - 1)
-											? "bg-indigo-9 text-white"
-											: "bg-gray-6 text-gray-10",
-								)}
-								disabled={isComplete}
-							>
-								{isPast || (isComplete && index <= currentIndex) ? (
-									<CheckCircle className="size-4" />
-								) : (
-									<step.icon className="size-4" />
-								)}
-							</button>
-							<span
-								className={cn(
-									"text-xs mt-1.5 hidden sm:block",
-									isActive ? "text-gray-12 font-medium" : "text-gray-10",
-								)}
-							>
-								{step.label}
-							</span>
-						</li>
-					);
-				})}
-			</ol>
-		</nav>
-	);
+  return (
+    <nav className="bg-gray-3/50 border-b border-gray-6 px-4 py-5">
+      <ol className="flex justify-between items-center relative">
+        {/* Line from center of first step to center of last step (4 steps = 12.5% / 87.5%) */}
+        <div className="absolute top-5 left-[12.5%] right-[12.5%] h-0.5 bg-gray-6 z-0 rounded-full">
+          <div
+            className="h-full bg-indigo-9 rounded-full transition-all duration-300"
+            style={{ width: progress }}
+          />
+        </div>
+        {steps.map((step, index) => {
+          const isActive = step.id === methods.state.current.data.id;
+          const isPast = index < currentIndex;
+          return (
+            <li
+              key={step.id}
+              className="flex flex-col items-center relative z-10 flex-1"
+            >
+              <button
+                type="button"
+                onClick={() => !isComplete && methods.navigation.goTo(step.id)}
+                className={cn(
+                  "size-9 rounded-full flex items-center justify-center transition-colors shrink-0",
+                  isPast || (isComplete && index < steps.length - 1)
+                    ? "bg-indigo-9 text-white"
+                    : isActive || (isComplete && index === steps.length - 1)
+                      ? "bg-indigo-9 text-white"
+                      : "bg-gray-6 text-gray-10",
+                )}
+                disabled={isComplete}
+              >
+                {isPast || (isComplete && index <= currentIndex) ? (
+                  <CheckCircle className="size-4" />
+                ) : (
+                  <step.icon className="size-4" />
+                )}
+              </button>
+              <span
+                className={cn(
+                  "text-xs mt-1.5 hidden sm:block",
+                  isActive ? "text-gray-12 font-medium" : "text-gray-10",
+                )}
+              >
+                {step.label}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
 };
 
 // #endregion StepperHeader
@@ -262,22 +281,43 @@ const StepperHeader = ({
 // #region PersonalInfoStep
 
 const PersonalInfoStep = ({
-	formData,
-	handleChange,
+  formData,
+  handleChange,
 }: {
-	formData: Record<string, string>;
-	handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  formData: Record<string, string>;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => (
-	<div>
-		<h3 className="text-base font-semibold text-gray-12 mb-4">Personal Information</h3>
-		<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-			<InputField label="First Name" name="firstName" value={formData.firstName} onChange={handleChange} required />
-			<InputField label="Last Name" name="lastName" value={formData.lastName} onChange={handleChange} required />
-			<div className="sm:col-span-2">
-				<InputField label="Email" name="email" type="email" value={formData.email} onChange={handleChange} required />
-			</div>
-		</div>
-	</div>
+  <div>
+    <h3 className="text-base font-semibold text-gray-12 mb-4">
+      Personal Information
+    </h3>
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <InputField
+        label="First Name"
+        name="firstName"
+        value={formData.firstName}
+        onChange={handleChange}
+        required
+      />
+      <InputField
+        label="Last Name"
+        name="lastName"
+        value={formData.lastName}
+        onChange={handleChange}
+        required
+      />
+      <div className="sm:col-span-2">
+        <InputField
+          label="Email"
+          name="email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+        />
+      </div>
+    </div>
+  </div>
 );
 
 // #endregion PersonalInfoStep
@@ -285,22 +325,40 @@ const PersonalInfoStep = ({
 // #region AddressStep
 
 const AddressStep = ({
-	formData,
-	handleChange,
+  formData,
+  handleChange,
 }: {
-	formData: Record<string, string>;
-	handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  formData: Record<string, string>;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => (
-	<div>
-		<h3 className="text-base font-semibold text-gray-12 mb-4">Address</h3>
-		<div className="space-y-4">
-			<InputField label="Street Address" name="address" value={formData.address} onChange={handleChange} required />
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-				<InputField label="City" name="city" value={formData.city} onChange={handleChange} required />
-				<InputField label="Zip Code" name="zipCode" value={formData.zipCode} onChange={handleChange} required />
-			</div>
-		</div>
-	</div>
+  <div>
+    <h3 className="text-base font-semibold text-gray-12 mb-4">Address</h3>
+    <div className="space-y-4">
+      <InputField
+        label="Street Address"
+        name="address"
+        value={formData.address}
+        onChange={handleChange}
+        required
+      />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <InputField
+          label="City"
+          name="city"
+          value={formData.city}
+          onChange={handleChange}
+          required
+        />
+        <InputField
+          label="Zip Code"
+          name="zipCode"
+          value={formData.zipCode}
+          onChange={handleChange}
+          required
+        />
+      </div>
+    </div>
+  </div>
 );
 
 // #endregion AddressStep
@@ -308,37 +366,50 @@ const AddressStep = ({
 // #region PaymentStep
 
 const PaymentStep = ({
-	formData,
-	handleChange,
+  formData,
+  handleChange,
 }: {
-	formData: Record<string, string>;
-	handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  formData: Record<string, string>;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => (
-	<div>
-		<h3 className="text-base font-semibold text-gray-12 mb-4">Payment</h3>
-		<div className="space-y-4">
-			<InputField label="Name on Card" name="cardName" value={formData.cardName} onChange={handleChange} required />
-			<InputField
-				label="Card Number"
-				name="cardNumber"
-				value={formData.cardNumber}
-				onChange={handleChange}
-				placeholder="XXXX XXXX XXXX XXXX"
-				required
-			/>
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-				<InputField
-					label="Expiry"
-					name="expiry"
-					value={formData.expiry}
-					onChange={handleChange}
-					placeholder="MM/YY"
-					required
-				/>
-				<InputField label="CVV" name="cvv" value={formData.cvv} onChange={handleChange} placeholder="XXX" required />
-			</div>
-		</div>
-	</div>
+  <div>
+    <h3 className="text-base font-semibold text-gray-12 mb-4">Payment</h3>
+    <div className="space-y-4">
+      <InputField
+        label="Name on Card"
+        name="cardName"
+        value={formData.cardName}
+        onChange={handleChange}
+        required
+      />
+      <InputField
+        label="Card Number"
+        name="cardNumber"
+        value={formData.cardNumber}
+        onChange={handleChange}
+        placeholder="XXXX XXXX XXXX XXXX"
+        required
+      />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <InputField
+          label="Expiry"
+          name="expiry"
+          value={formData.expiry}
+          onChange={handleChange}
+          placeholder="MM/YY"
+          required
+        />
+        <InputField
+          label="CVV"
+          name="cvv"
+          value={formData.cvv}
+          onChange={handleChange}
+          placeholder="XXX"
+          required
+        />
+      </div>
+    </div>
+  </div>
 );
 
 // #endregion PaymentStep
@@ -346,20 +417,20 @@ const PaymentStep = ({
 // #region CompletionScreen
 
 const CompletionScreen = ({ onReset }: { onReset: () => void }) => (
-	<div className="text-center py-8">
-		<div className="size-14 bg-green-9 rounded-full flex items-center justify-center mx-auto mb-4">
-			<CheckCircle className="size-7 text-white" />
-		</div>
-		<h3 className="text-lg font-semibold text-gray-12 mb-1">Done!</h3>
-		<p className="text-sm text-gray-11 mb-6">Form submitted successfully.</p>
-		<button
-			type="button"
-			onClick={onReset}
-			className="px-4 py-2 text-sm font-medium rounded-lg text-white bg-indigo-9 hover:bg-indigo-10 transition-colors"
-		>
-			Start over
-		</button>
-	</div>
+  <div className="text-center py-8">
+    <div className="size-14 bg-green-9 rounded-full flex items-center justify-center mx-auto mb-4">
+      <CheckCircle className="size-7 text-white" />
+    </div>
+    <h3 className="text-lg font-semibold text-gray-12 mb-1">Done!</h3>
+    <p className="text-sm text-gray-11 mb-6">Form submitted successfully.</p>
+    <button
+      type="button"
+      onClick={onReset}
+      className="px-4 py-2 text-sm font-medium rounded-lg text-white bg-indigo-9 hover:bg-indigo-10 transition-colors"
+    >
+      Start over
+    </button>
+  </div>
 );
 
 // #endregion CompletionScreen

--- a/apps/docs/components/home/demo-section.tsx
+++ b/apps/docs/components/home/demo-section.tsx
@@ -128,7 +128,7 @@ const DemoContent = () => {
 							{!methods.state.isFirst && (
 								<button
 									type="button"
-									onClick={methods.navigation.prev}
+									onClick={() => methods.navigation.prev()}
 									className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-7 text-gray-12 hover:bg-gray-4 transition-colors"
 								>
 									Back

--- a/apps/docs/components/ui/label.tsx
+++ b/apps/docs/components/ui/label.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import { Label as LabelPrimitive } from "radix-ui";
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({
   className,
@@ -14,11 +14,11 @@ function Label({
       data-slot="label"
       className={cn(
         "gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/apps/docs/components/ui/popover.tsx
+++ b/apps/docs/components/ui/popover.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Popover as PopoverPrimitive } from "radix-ui";
-import * as React from "react";
+import React from "react";
 import { cn } from "@/lib/utils";
 
 const Popover = PopoverPrimitive.Root;
@@ -8,22 +8,22 @@ const Popover = PopoverPrimitive.Root;
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverContent = React.forwardRef<
-	React.ComponentRef<typeof PopoverPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-	<PopoverPrimitive.Portal>
-		<PopoverPrimitive.Content
-			ref={ref}
-			align={align}
-			sideOffset={sideOffset}
-			side="bottom"
-			className={cn(
-				"z-50 min-w-[220px] max-w-[98vw] rounded-lg border bg-fd-popover p-2 text-sm text-fd-popover-foreground shadow-lg focus-visible:outline-none data-[state=closed]:animate-fd-popover-out data-[state=open]:animate-fd-popover-in",
-				className,
-			)}
-			{...props}
-		/>
-	</PopoverPrimitive.Portal>
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      side="bottom"
+      className={cn(
+        "z-50 min-w-[220px] max-w-[98vw] rounded-lg border bg-fd-popover p-2 text-sm text-fd-popover-foreground shadow-lg focus-visible:outline-none data-[state=closed]:animate-fd-popover-out data-[state=open]:animate-fd-popover-in",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 

--- a/apps/docs/components/ui/scroll-area.tsx
+++ b/apps/docs/components/ui/scroll-area.tsx
@@ -1,48 +1,56 @@
 import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
-import * as React from "react";
+import React from "react";
 import { cn } from "@/lib/utils";
 
 const ScrollArea = React.forwardRef<
-	React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+  React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
-	<ScrollAreaPrimitive.Root ref={ref} className={cn("overflow-hidden", className)} {...props}>
-		{children}
-		<ScrollAreaPrimitive.Corner />
-		<ScrollBar orientation="vertical" />
-	</ScrollAreaPrimitive.Root>
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("overflow-hidden", className)}
+    {...props}
+  >
+    {children}
+    <ScrollAreaPrimitive.Corner />
+    <ScrollBar orientation="vertical" />
+  </ScrollAreaPrimitive.Root>
 ));
 
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollViewport = React.forwardRef<
-	React.ComponentRef<typeof ScrollAreaPrimitive.Viewport>,
-	React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Viewport>
+  React.ComponentRef<typeof ScrollAreaPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Viewport>
 >(({ className, children, ...props }, ref) => (
-	<ScrollAreaPrimitive.Viewport ref={ref} className={cn("size-full rounded-[inherit]", className)} {...props}>
-		{children}
-	</ScrollAreaPrimitive.Viewport>
+  <ScrollAreaPrimitive.Viewport
+    ref={ref}
+    className={cn("size-full rounded-[inherit]", className)}
+    {...props}
+  >
+    {children}
+  </ScrollAreaPrimitive.Viewport>
 ));
 
 ScrollViewport.displayName = ScrollAreaPrimitive.Viewport.displayName;
 
 const ScrollBar = React.forwardRef<
-	React.ComponentRef<typeof ScrollAreaPrimitive.Scrollbar>,
-	React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
+  React.ComponentRef<typeof ScrollAreaPrimitive.Scrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
 >(({ className, orientation = "vertical", ...props }, ref) => (
-	<ScrollAreaPrimitive.Scrollbar
-		ref={ref}
-		orientation={orientation}
-		className={cn(
-			"flex select-none data-[state=hidden]:animate-fd-fade-out",
-			orientation === "vertical" && "h-full w-1.5",
-			orientation === "horizontal" && "h-1.5 flex-col",
-			className,
-		)}
-		{...props}
-	>
-		<ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-fd-border" />
-	</ScrollAreaPrimitive.Scrollbar>
+  <ScrollAreaPrimitive.Scrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex select-none data-[state=hidden]:animate-fd-fade-out",
+      orientation === "vertical" && "h-full w-1.5",
+      orientation === "horizontal" && "h-1.5 flex-col",
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-fd-border" />
+  </ScrollAreaPrimitive.Scrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.Scrollbar.displayName;
 

--- a/apps/docs/components/ui/separator.tsx
+++ b/apps/docs/components/ui/separator.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Separator({
   className,
@@ -18,11 +18,11 @@ function Separator({
       orientation={orientation}
       className={cn(
         "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/apps/docs/components/ui/tabs.tsx
+++ b/apps/docs/components/ui/tabs.tsx
@@ -1,57 +1,66 @@
 "use client";
 import { Tabs as TabsPrimitive } from "radix-ui";
-import * as React from "react";
+import React from "react";
 import { cn } from "@/lib/utils";
 
 const Tabs = React.forwardRef<
-	React.ComponentRef<typeof TabsPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+  React.ComponentRef<typeof TabsPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
 >((props, ref) => {
-	return (
-		<TabsPrimitive.Root
-			ref={ref}
-			{...props}
-			className={cn("flex flex-col overflow-hidden rounded-xl border bg-fd-card", props.className)}
-		/>
-	);
+  return (
+    <TabsPrimitive.Root
+      ref={ref}
+      {...props}
+      className={cn(
+        "flex flex-col overflow-hidden rounded-xl border bg-fd-card",
+        props.className,
+      )}
+    />
+  );
 });
 
 Tabs.displayName = "Tabs";
 
 const TabsList = React.forwardRef<
-	React.ComponentRef<typeof TabsPrimitive.List>,
-	React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+  React.ComponentRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >((props, ref) => (
-	<TabsPrimitive.List
-		ref={ref}
-		{...props}
-		className={cn(
-			"flex flex-row items-end gap-4 overflow-x-auto bg-fd-secondary px-4 text-fd-muted-foreground",
-			props.className,
-		)}
-	/>
+  <TabsPrimitive.List
+    ref={ref}
+    {...props}
+    className={cn(
+      "flex flex-row items-end gap-4 overflow-x-auto bg-fd-secondary px-4 text-fd-muted-foreground",
+      props.className,
+    )}
+  />
 ));
 TabsList.displayName = "TabsList";
 
 const TabsTrigger = React.forwardRef<
-	React.ComponentRef<typeof TabsPrimitive.Trigger>,
-	React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+  React.ComponentRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >((props, ref) => (
-	<TabsPrimitive.Trigger
-		ref={ref}
-		{...props}
-		className={cn(
-			"whitespace-nowrap border-b border-transparent py-2 text-sm font-medium transition-colors hover:text-fd-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-fd-primary data-[state=active]:text-fd-primary",
-			props.className,
-		)}
-	/>
+  <TabsPrimitive.Trigger
+    ref={ref}
+    {...props}
+    className={cn(
+      "whitespace-nowrap border-b border-transparent py-2 text-sm font-medium transition-colors hover:text-fd-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-fd-primary data-[state=active]:text-fd-primary",
+      props.className,
+    )}
+  />
 ));
 TabsTrigger.displayName = "TabsTrigger";
 
 const TabsContent = React.forwardRef<
-	React.ComponentRef<typeof TabsPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->((props, ref) => <TabsPrimitive.Content ref={ref} {...props} className={cn("p-4", props.className)} />);
+  React.ComponentRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>((props, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    {...props}
+    className={cn("p-4", props.className)}
+  />
+));
 TabsContent.displayName = "TabsContent";
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/docs/content/docs/react/api-references/hook.mdx
+++ b/apps/docs/content/docs/react/api-references/hook.mdx
@@ -269,9 +269,11 @@ function LookupExample() {
 
 ## Transition hooks (before / after)
 
-For actions before or after a transition (e.g. validation, analytics), use **`stepper.lifecycle.onBeforeTransition(cb)`** and **`stepper.lifecycle.onAfterTransition(cb)`**. They run on every `next()`, `prev()`, and `goTo()`. Return `false` (or a promise that resolves to `false`) from `onBeforeTransition` to cancel the transition.
+For actions before or after a transition (e.g. validation, analytics), use **`stepper.lifecycle.onBeforeTransition(cb)`** and **`stepper.lifecycle.onAfterTransition(cb)`**. Multiple callbacks are supported (e.g. one at the Stepper level, one per step); each call returns an **unsubscribe** function. They run on every `next()`, `prev()`, and `goTo()`. Return `false` (or a promise that resolves to `false`) from `onBeforeTransition` to cancel the transition.
 
 The callback receives a **TransitionContext** with: `from`, `to`, `metadata`, `statuses`, `direction` (`"next"` | `"prev"` | `"goTo"`), `fromIndex`, `toIndex`. Use `direction` to branch (e.g. run logic only before "next" or "prev").
+
+To avoid stale metadata in the hook when you set metadata and then call `next()`, `prev()`, or `goTo()` in the same handler, pass a **payload** into navigation: **`next({ metadata: { "step-id": { ... } } })`**, **`prev({ metadata: ... })`**, or **`goTo(id, { metadata: ... })`**. That metadata is merged into `ctx.metadata` for the transition and persisted.
 
 ### onBeforeTransition
 
@@ -289,9 +291,10 @@ const { useStepper } = defineStepper(
 function MyStepper() {
   const stepper = useStepper();
   React.useEffect(() => {
-    stepper.lifecycle.onBeforeTransition(async (ctx) => {
+    const unsub = stepper.lifecycle.onBeforeTransition(async (ctx) => {
       if (ctx.direction === "prev" && !window.confirm("Go back?")) return false;
     });
+    return () => unsub();
   }, [stepper]);
   return (
     <button type="button" onClick={() => stepper.navigation.next()} disabled={stepper.state.isLast}>
@@ -299,6 +302,79 @@ function MyStepper() {
     </button>
   );
 }
+```
+
+### Multiple callbacks (Stepper + step) and unsubscribe
+
+You can register one handler at the Stepper level and another inside a step component; **all run in registration order**. If any `onBeforeTransition` callback returns `false`, the transition is cancelled. Each call returns an **unsubscribe** function — use it in your `useEffect` cleanup so the handler is removed when the component unmounts (e.g. when navigating away from that step).
+
+```tsx twoslash
+import * as React from "react";
+import { defineStepper } from "@stepperize/react";
+
+const { useStepper } = defineStepper(
+  { id: "step-1", title: "Step 1" },
+  { id: "step-2", title: "Step 2" }
+);
+
+function StepperWrapper() {
+  const stepper = useStepper();
+  React.useEffect(() => {
+    const unsub = stepper.lifecycle.onBeforeTransition(async (ctx) => {
+      if (ctx.direction === "prev" && !window.confirm("Go back?")) return false;
+    });
+    return () => unsub();
+  }, [stepper]);
+  return (
+    <>
+      {stepper.flow.switch({
+        "step-1": () => <Step1 />,
+        "step-2": () => <Step2 />,
+      })}
+    </>
+  );
+}
+
+function Step1() {
+  const stepper = useStepper();
+  React.useEffect(() => {
+    const unsub = stepper.lifecycle.onBeforeTransition(async (ctx) => {
+      if (ctx.from.id === "step-1") {
+        // Step-specific validation; both this and the global handler run
+        const ok = await validateStep1();
+        if (!ok) return false;
+      }
+    });
+    return () => unsub();
+  }, [stepper]);
+  return (
+    <button type="button" onClick={() => stepper.navigation.next()}>
+      Next
+    </button>
+  );
+}
+
+function Step2() {
+  return <p>Step 2</p>;
+}
+
+async function validateStep1(): Promise<boolean> {
+  return true;
+}
+```
+
+### Passing metadata in the transition (avoid stale ctx)
+
+If you set metadata and then call `next()` in the same handler, `onBeforeTransition` still sees the previous metadata (setState is async). Pass a payload so the hook receives fresh data. The same payload works for **`next(payload)`**, **`prev(payload)`**, and **`goTo(id, payload)`**:
+
+```tsx
+const handleNext = async () => {
+  const url = await generateUrl();
+  stepper.navigation.next({ metadata: { "step-1": { ...step1Meta, data: { url } } } });
+};
+
+stepper.navigation.prev({ metadata: { "step-1": { reason: "back" } } });
+stepper.navigation.goTo("summary", { metadata: { "payment": { method: "card" } } });
 ```
 
 ### onAfterTransition
@@ -317,9 +393,10 @@ const { useStepper } = defineStepper(
 function MyStepper() {
   const stepper = useStepper();
   React.useEffect(() => {
-    stepper.lifecycle.onAfterTransition((ctx) => {
+    const unsub = stepper.lifecycle.onAfterTransition((ctx) => {
       console.log(`${ctx.from.id} → ${ctx.to.id}`);
     });
+    return () => unsub();
   }, [stepper]);
   return (
     <button type="button" onClick={() => stepper.navigation.next()} disabled={stepper.state.isLast}>
@@ -396,8 +473,8 @@ const MyStepperComponent = () => {
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | `state` | `StepperState<Steps>` | `all`, `current` (data, index, status, metadata), `isFirst`, `isLast`, `isTransitioning` |
-| `navigation` | `StepperNavigation<Steps>` | `next()`, `prev()`, `goTo(id)`, `reset()` |
+| `navigation` | `StepperNavigation<Steps>` | `next(payload?)`, `prev(payload?)`, `goTo(id, payload?)`, `reset()` — payload can include `metadata` to merge into transition context |
 | `lookup` | `StepperLookup<Steps>` | `getAll()`, `get(id)`, `getIndex(id)`, `getByIndex(index)`, `getFirst()` / `getLast()`, `getNext(id)` / `getPrev(id)`, `getNeighbors(id)` |
 | `flow` | `StepperFlow<Steps>` | `is(id)`, `when(id, whenFn, elseFn?)`, `switch(when)`, `match(state, matches)` |
 | `metadata` | `StepperMetadata<Steps>` | `values`, `set(id, values)`, `get(id)`, `reset(keepInitialMetadata?)` |
-| `lifecycle` | `{ onBeforeTransition, onAfterTransition }` | Register callbacks for every transition; return `false` from `onBeforeTransition` to cancel |
+| `lifecycle` | `{ onBeforeTransition, onAfterTransition }` | Register callbacks (multiple supported); each returns unsubscribe; return `false` from `onBeforeTransition` to cancel |

--- a/apps/docs/content/docs/react/api-references/hook.mdx
+++ b/apps/docs/content/docs/react/api-references/hook.mdx
@@ -13,7 +13,7 @@ The hook accepts an optional single argument: a config object with:
 ## Usage
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -42,7 +42,7 @@ The stepper exposes **`flow`** with helpers to render content by step: **`flow.i
 The `flow.when` method allows rendering content conditionally based on the current step. It takes a step ID (string or array of ID plus conditions), a `whenFn` (the function to run if the step matches), and an optional `elseFn` (run when it does not match).
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -68,7 +68,7 @@ const MyStepperComponent = () => {
 You can pass an optional `elseFn` to render when the current step does not match:
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -94,7 +94,7 @@ function Content() {
 You can also use an array as the first argument: the first element is the step ID, the rest are boolean conditions. The step matches only when the ID matches and all conditions are `true`. This allows multi-condition logic (e.g. step + feature flag or validation state).
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -124,7 +124,7 @@ const MyStepperComponent = () => {
 The `flow.switch` method lets you render content based on the current step ID in a switch-case style. It is a cleaner and more scalable way to handle many steps without multiple `when` conditions.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -150,7 +150,7 @@ const MyStepperComponent = () => {
 The `flow.match` method lets you render content based on an **external** step ID (e.g. from the server, URL, or other state). Unlike `flow.switch`, which uses the stepper’s current step, `flow.match` takes that ID as the first argument. Useful for frameworks like Remix with server-side state or when driving the UI from a URL param.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -177,7 +177,7 @@ const MyStepperComponent = () => {
 For simple conditionals, use `flow.is(id)`. It returns `true` when the current step’s ID equals `id`.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -210,7 +210,7 @@ function Content() {
 | `navigation.reset()` | Reset to initial step |
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -248,7 +248,7 @@ Step lookup helpers (same shape as `generateStepperUtils` from `@stepperize/core
 | `lookup.getNeighbors(id)` | `{ prev, next }` for step `id` |
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -280,7 +280,7 @@ To avoid stale metadata in the hook when you set metadata and then call `next()`
 Runs before the step index updates. Return `false` to cancel.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -309,7 +309,7 @@ function MyStepper() {
 You can register one handler at the Stepper level and another inside a step component; **all run in registration order**. If any `onBeforeTransition` callback returns `false`, the transition is cancelled. Each call returns an **unsubscribe** function — use it in your `useEffect` cleanup so the handler is removed when the component unmounts (e.g. when navigating away from that step).
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -382,7 +382,7 @@ stepper.navigation.goTo("summary", { metadata: { "payment": { method: "card" } }
 Runs after the step index has updated.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -415,7 +415,7 @@ Metadata lets you attach custom data per step (e.g. form drafts, values from the
 Pass **`initialMetadata`** in `useStepper({ ... })` to seed metadata per step:
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(
@@ -443,7 +443,7 @@ const MyStepperComponent = () => {
 Current step only: **`state.current.metadata.get()`**, **`state.current.metadata.set(values)`**, **`state.current.metadata.reset()`**.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(

--- a/apps/docs/content/docs/react/api-references/hook.mdx
+++ b/apps/docs/content/docs/react/api-references/hook.mdx
@@ -273,7 +273,7 @@ For actions before or after a transition (e.g. validation, analytics), use **`st
 
 The callback receives a **TransitionContext** with: `from`, `to`, `metadata`, `statuses`, `direction` (`"next"` | `"prev"` | `"goTo"`), `fromIndex`, `toIndex`. Use `direction` to branch (e.g. run logic only before "next" or "prev").
 
-To avoid stale metadata in the hook when you set metadata and then call `next()`, `prev()`, or `goTo()` in the same handler, pass a **payload** into navigation: **`next({ metadata: { "step-id": { ... } } })`**, **`prev({ metadata: ... })`**, or **`goTo(id, { metadata: ... })`**. That metadata is merged into `ctx.metadata` for the transition and persisted.
+To avoid stale metadata in the hook when you set metadata and then call `next()`, `prev()`, or `goTo()` in the same handler, pass a **payload** into navigation: **`next({ metadata: { "step-id": { ... } } })`**, **`prev({ metadata: ... })`**, or **`goTo(id, { metadata: ... })`**. That metadata is merged into `ctx.metadata` for the transition and persisted when the transition completes. **If an `onBeforeTransition` callback returns `false` and cancels the transition, the payload (including any `metadata`) is not persisted** — the step index and metadata state stay as they were. If you need to commit metadata even when the transition is cancelled, call `stepper.metadata.set(id, values)` (or `stepper.state.current.metadata.set(values)`) inside the before callback.
 
 ### onBeforeTransition
 

--- a/apps/docs/content/docs/react/api-references/lookup.mdx
+++ b/apps/docs/content/docs/react/api-references/lookup.mdx
@@ -26,7 +26,7 @@ There is no `has` or `count`; use `stepper.lookup.get(id) != null` and `stepper.
 ## Usage with useStepper
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(

--- a/apps/docs/content/docs/react/api-references/primitives.mdx
+++ b/apps/docs/content/docs/react/api-references/primitives.mdx
@@ -8,7 +8,7 @@ The `Stepper` object returned by `defineStepper` provides a set of primitive com
 ## Overview
 
 ```tsx twoslash
-import * as React from "react"
+import React from "react"
 import { defineStepper } from "@stepperize/react"
 
 const { Stepper } = defineStepper(
@@ -190,7 +190,7 @@ import { useStepItemContext } from "@stepperize/react/primitives";
 Use `item.index` to show a numeric indicator (1, 2, 3) without passing the step id:
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 import { useStepItemContext } from "@stepperize/react/primitives";
 
@@ -233,7 +233,7 @@ function MyStepper() {
 Use `item.status` to change the trigger's appearance (e.g. active vs inactive) without comparing step ids yourself:
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 import { useStepItemContext } from "@stepperize/react/primitives";
 
@@ -773,7 +773,7 @@ Use data attributes for CSS styling. Step status is one of `"active"`, `"success
 ## Complete Example
 
 ```tsx twoslash
-import * as React from "react"
+import React from "react"
 import { defineStepper } from "@stepperize/react"
 
 const { Stepper, useStepper } = defineStepper(

--- a/apps/docs/content/docs/react/api-references/schema-validation.mdx
+++ b/apps/docs/content/docs/react/api-references/schema-validation.mdx
@@ -64,7 +64,7 @@ const { useStepper } = defineStepper(
 Steps are plain objects; you can add a `schema` (or any key) to each step. Access via the stepper:
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { z } from "zod";
 import { defineStepper } from "@stepperize/react";
 

--- a/apps/docs/content/docs/react/api-references/scoped.mdx
+++ b/apps/docs/content/docs/react/api-references/scoped.mdx
@@ -8,7 +8,7 @@ description: Share stepper state with the Scoped component
 ## Basic usage
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -53,7 +53,7 @@ const StepNavigation = () => {
 | `children` | `React.ReactNode` | Content to render |
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -82,7 +82,7 @@ const StepContent = () => {
 You can nest different steppers (e.g. global wizard + local sub-steps):
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const GlobalStepper = defineStepper(
@@ -121,7 +121,7 @@ const LocalStepContent = () => {
 `Stepper.Root` wraps content and provides the stepper via context (it uses `Scoped` internally). `Stepper.Root` accepts `initialStep` and `initialMetadata` and passes them to Scoped internally; use either Root or Scoped to set initial state.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Stepper, useStepper } = defineStepper(

--- a/apps/docs/content/docs/react/api-references/types.mdx
+++ b/apps/docs/content/docs/react/api-references/types.mdx
@@ -89,7 +89,7 @@ type TransitionPayload<Steps> = {
 };
 ```
 
-Merged into `ctx.metadata` for that transition and persisted, so `onBeforeTransition` / `onAfterTransition` see up-to-date metadata without waiting for `metadata.set()` to flush.
+Merged into `ctx.metadata` for that transition and persisted when the transition completes, so `onBeforeTransition` / `onAfterTransition` see up-to-date metadata without waiting for `metadata.set()` to flush. If a transition is cancelled (e.g. `onBeforeTransition` returns `false`), the payload is not persisted.
 
 ### TransitionDirection
 

--- a/apps/docs/content/docs/react/api-references/types.mdx
+++ b/apps/docs/content/docs/react/api-references/types.mdx
@@ -28,11 +28,11 @@ type Metadata = Record<string, any> | null;
 The stepper instance type has six namespaces:
 
 - **state**: `StepperState<Steps>` — `all`, `current` (data, index, status, metadata), `isFirst`, `isLast`, `isTransitioning`
-- **navigation**: `StepperNavigation<Steps>` — `next`, `prev`, `goTo`, `reset`
+- **navigation**: `StepperNavigation<Steps>` — `next(payload?)`, `prev(payload?)`, `goTo(id, payload?)`, `reset` — see **TransitionPayload**
 - **lookup**: `StepperLookup<Steps>` — `getAll`, `get`, `getIndex`, `getByIndex`, `getFirst`, `getLast`, `getNext`, `getPrev`, `getNeighbors`
 - **flow**: `StepperFlow<Steps>` — `is`, `when`, `switch`, `match`
 - **metadata**: `StepperMetadata<Steps>` — `values`, `set`, `get`, `reset`
-- **lifecycle**: `StepperLifecycle<Steps>` — `onBeforeTransition`, `onAfterTransition`
+- **lifecycle**: `StepperLifecycle<Steps>` — `onBeforeTransition(cb)` / `onAfterTransition(cb)` (each returns unsubscribe; multiple callbacks supported)
 
 Transition state is `state.isTransitioning`. See [Hook](./hook#transition-hooks).
 
@@ -78,6 +78,18 @@ type TransitionContext<Steps> = {
   readonly toIndex: number;
 };
 ```
+
+### TransitionPayload (from @stepperize/core)
+
+Optional payload for `next(payload?)`, `prev(payload?)`, `goTo(id, payload?)`:
+
+```ts
+type TransitionPayload<Steps> = {
+  metadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+};
+```
+
+Merged into `ctx.metadata` for that transition and persisted, so `onBeforeTransition` / `onAfterTransition` see up-to-date metadata without waiting for `metadata.set()` to flush.
 
 ### TransitionDirection
 

--- a/apps/docs/content/docs/react/examples/basic.mdx
+++ b/apps/docs/content/docs/react/examples/basic.mdx
@@ -32,7 +32,7 @@ const { Stepper, Scoped } = defineStepper(
 `Stepper.Root` provides the stepper context (it uses Scoped internally) and passes the stepper to your render function. Use `orientation="horizontal"` (default) for a horizontal layout.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Stepper } = defineStepper(
@@ -62,7 +62,7 @@ function HorizontalStepper() {
 Map over `stepper.state.all` and render one `Stepper.Item` per step. Each item needs a `Trigger` (and optionally `Title`, `Indicator`, `Separator`).
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Stepper } = defineStepper(
@@ -102,7 +102,7 @@ function StepList() {
 Use `Stepper.Content` with a `step` prop so each panel is visible only when that step is current.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Stepper } = defineStepper(
@@ -143,7 +143,7 @@ Put `Stepper.Prev` and `Stepper.Next` inside `Stepper.Actions`. They call `navig
 ### Full example
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Stepper } = defineStepper(
@@ -224,7 +224,7 @@ Pass `orientation="vertical"` to `Stepper.Root` and `Stepper.List`. Use a custom
 ### Full example
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Stepper } = defineStepper(
@@ -303,7 +303,7 @@ By default, `Stepper.Indicator` has no built-in content. You control what it sho
 ### Custom indicator with step index
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 import { useStepItemContext } from "@stepperize/react/primitives";
 
@@ -351,7 +351,7 @@ function StepperWithNumberedIndicator() {
 You can also use the `render` prop to receive DOM props and render a custom element (e.g. for styling the “circle” later).
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 import { useStepItemContext } from "@stepperize/react/primitives";
 
@@ -388,7 +388,7 @@ function CustomIndicator() {
 ### Full example
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 import { useStepItemContext } from "@stepperize/react/primitives";
 

--- a/apps/docs/content/docs/react/examples/conform-react.mdx
+++ b/apps/docs/content/docs/react/examples/conform-react.mdx
@@ -41,7 +41,7 @@ const { Scoped, useStepper } = defineStepper(
 Wrap your form tree with `<Scoped>` so child components can call `useStepper()` and access the current step and its schema.
 
 ```tsx
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -75,7 +75,7 @@ function StepNavigation() {
 In your form component, call `useStepper()` and read the current step's schema from `stepper.state.current.data.schema`. Pass that schema to Conform's `useForm` (e.g. with `parseWithZod`). Use `getFormProps(form)` on your `<form>` and Conform's field helpers for inputs.
 
 ```tsx
-import * as React from "react";
+import React from "react";
 import { useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod/v4/future";
 import { z } from "zod";
@@ -174,7 +174,7 @@ Use `stepper.state.current.metadata` or `stepper.metadata.get(id)` to store per-
 ## Full example
 
 ```tsx
-zimport * as React from "react";
+zimport React from "react";
 import { useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod/v4/future";
 import { z } from "zod";

--- a/apps/docs/content/docs/react/examples/react-hook-form.mdx
+++ b/apps/docs/content/docs/react/examples/react-hook-form.mdx
@@ -41,7 +41,7 @@ const { Scoped, useStepper } = defineStepper(
 Wrap your form tree with `<Scoped>` so child components can call `useStepper()` and access the current step and its schema.
 
 ```tsx
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -75,7 +75,7 @@ function StepNavigation() {
 In your form component, call `useStepper()` and read the current step's schema from `stepper.state.current.data.schema`. Use RHF's `useForm` with `zodResolver(schema)` (and optionally `defaultValues` from metadata). Call `handleSubmit(onValid)` so that when the user submits, you only advance to the next step if validation passes.
 
 ```tsx
-import * as React from "react";
+import React from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -175,7 +175,7 @@ function StepNavigation() {
 ## Full example
 
 ```tsx
-import * as React from "react";
+import React from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";

--- a/apps/docs/content/docs/react/examples/scoped.mdx
+++ b/apps/docs/content/docs/react/examples/scoped.mdx
@@ -18,7 +18,7 @@ Use `defineStepper` with one object per step. For a single stepper you destructu
 One stepper: wrap your tree with `<Scoped>` and call `useStepper()` in children.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -62,7 +62,7 @@ const LocalStepper = defineStepper(
   <Tab value="Single scope">
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -95,7 +95,7 @@ function StepNavigation() {
   <Tab value="Multi-scoped">
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const GlobalStepper = defineStepper(
@@ -177,7 +177,7 @@ For **single scope** the pattern is the same in every child. For **multi-scoped*
   <Tab value="Single scope">
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -219,7 +219,7 @@ In another child component, call the same `useStepper()` (or the matching one in
   <Tab value="Single scope">
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -272,7 +272,7 @@ Use `GlobalStepper.useStepper()` for global nav (Back / Next / Reset) and `Local
 Pass `initialStep` and/or `initialMetadata` to `Scoped` to set the starting step and initial metadata per step.
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -352,7 +352,7 @@ function GlobalStepGate({ children }: { children: React.ReactNode }) {
   <Tab value="Single scope">
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { Scoped, useStepper } = defineStepper(
@@ -413,7 +413,7 @@ export function ScopedStepper() {
   <Tab value="Multi-scoped">
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const GlobalStepper = defineStepper(

--- a/apps/docs/content/docs/react/migration/migrating-to-v6.mdx
+++ b/apps/docs/content/docs/react/migration/migrating-to-v6.mdx
@@ -110,8 +110,10 @@ See [Scoped](/docs/react/api-references/scoped).
 
 **Now:** Register callbacks on the stepper instance:
 
-- `stepper.lifecycle.onBeforeTransition(cb)` — runs before every `next` / `prev` / `goTo`. Return `false` (or a promise that resolves to `false`) to cancel.
-- `stepper.lifecycle.onAfterTransition(cb)` — runs after the transition.
+- `stepper.lifecycle.onBeforeTransition(cb)` — runs before every `next` / `prev` / `goTo`. Return `false` (or a promise that resolves to `false`) to cancel. **Multiple callbacks** are supported (e.g. one at Stepper level, one per step); each returns an unsubscribe function.
+- `stepper.lifecycle.onAfterTransition(cb)` — runs after the transition; same multi-callback / unsubscribe behavior.
+
+You can pass **metadata in the transition** so the hook sees fresh data: `next({ metadata: { "step-id": { ... } } })` instead of `metadata.set()` + `next()` (which would give stale `ctx.metadata` in the hook).
 
 The callback receives a **TransitionContext**: `from`, `to`, `metadata`, `statuses`, `direction` (`"next"` | `"prev"` | `"goTo"`), `fromIndex`, `toIndex`.
 

--- a/apps/docs/content/docs/react/my-first-stepper.mdx
+++ b/apps/docs/content/docs/react/my-first-stepper.mdx
@@ -76,7 +76,7 @@ function MyStepper() {
 ## Full example
 
 ```tsx twoslash
-import * as React from "react";
+import React from "react";
 import { defineStepper } from "@stepperize/react";
 
 const { useStepper } = defineStepper(

--- a/apps/docs/registry/base-ui/blocks/stepper-with-scroll-tracking/components/stepper-with-scroll-tracking.tsx
+++ b/apps/docs/registry/base-ui/blocks/stepper-with-scroll-tracking/components/stepper-with-scroll-tracking.tsx
@@ -1,260 +1,251 @@
 "use client";
 
-import { defineStepper, Get } from "@stepperize/react";
-import { StepStatus, useStepItemContext } from "@stepperize/react/primitives";
-import * as React from "react";
+import { defineStepper, type Get } from "@stepperize/react";
+import {
+  type StepStatus,
+  useStepItemContext,
+} from "@stepperize/react/primitives";
+import React from "react";
 
 import { Button } from "@/registry/base-ui/ui/button";
 
 const { Stepper, ...stepperDefinition } = defineStepper(
-	{
-		id: "introduction",
-		title: "Introduction",
-		description: "Welcome to the tutorial",
-	},
-	{
-		id: "basics",
-		title: "Basics",
-		description: "Learn the fundamentals",
-	},
-	{
-		id: "advanced",
-		title: "Advanced",
-		description: "Deep dive into advanced topics",
-	},
-	{
-		id: "practice",
-		title: "Practice",
-		description: "Apply what you learned",
-	},
-	{
-		id: "certification",
-		title: "Certification",
-		description: "Get your certificate",
-	}
+  {
+    id: "introduction",
+    title: "Introduction",
+    description: "Welcome to the tutorial",
+  },
+  {
+    id: "basics",
+    title: "Basics",
+    description: "Learn the fundamentals",
+  },
+  {
+    id: "advanced",
+    title: "Advanced",
+    description: "Deep dive into advanced topics",
+  },
+  {
+    id: "practice",
+    title: "Practice",
+    description: "Apply what you learned",
+  },
+  {
+    id: "certification",
+    title: "Certification",
+    description: "Get your certificate",
+  },
 );
 
 const StepperTriggerWrapper = () => {
-	const item = useStepItemContext();
-	const isInactive = item.status === "inactive";
+  const item = useStepItemContext();
+  const isInactive = item.status === "inactive";
 
-	return (
-		<Stepper.Trigger
-			render={(domProps) => (
-				<Button
-					className="rounded-full"
-					variant={isInactive ? "secondary" : "default"}
-					size="icon"
-					{...domProps}
-				>
-					<Stepper.Indicator>
-						{item.index + 1}
-					</Stepper.Indicator>
-				</Button>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Trigger
+      render={(domProps) => (
+        <Button
+          className="rounded-full"
+          variant={isInactive ? "secondary" : "default"}
+          size="icon"
+          {...domProps}
+        >
+          <Stepper.Indicator>{item.index + 1}</Stepper.Indicator>
+        </Button>
+      )}
+    />
+  );
 };
 
 const StepperTitleWrapper = ({ title }: { title: string }) => {
-	return (
-		<Stepper.Title
-			render={(domProps) => (
-				<h4 className="text-base font-medium" {...domProps}>
-					{title}
-				</h4>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Title
+      render={(domProps) => (
+        <h4 className="text-base font-medium" {...domProps}>
+          {title}
+        </h4>
+      )}
+    />
+  );
 };
 
 const StepperDescriptionWrapper = ({
-	description,
-}: { description?: string }) => {
-	if (!description) return null;
-	return (
-		<Stepper.Description
-			render={(domProps) => (
-				<p className="text-sm text-muted-foreground" {...domProps}>
-					{description}
-				</p>
-			)}
-		/>
-	);
+  description,
+}: {
+  description?: string;
+}) => {
+  if (!description) return null;
+  return (
+    <Stepper.Description
+      render={(domProps) => (
+        <p className="text-sm text-muted-foreground" {...domProps}>
+          {description}
+        </p>
+      )}
+    />
+  );
 };
 
 const StepperSeparatorVertical = ({
-	status,
-	isLast,
-}: { status: StepStatus; isLast: boolean }) => {
-	if (isLast) return null;
+  status,
+  isLast,
+}: {
+  status: StepStatus;
+  isLast: boolean;
+}) => {
+  if (isLast) return null;
 
-	return (
-		<div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
-			<Stepper.Separator
-				orientation="vertical"
-				data-status={status}
-				className="w-0.5 h-full bg-muted data-[status=success]:bg-primary transition-all duration-300 ease-in-out"
-			/>
-		</div>
-	);
+  return (
+    <div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
+      <Stepper.Separator
+        orientation="vertical"
+        data-status={status}
+        className="w-0.5 h-full bg-muted data-[status=success]:bg-primary transition-all duration-300 ease-in-out"
+      />
+    </div>
+  );
 };
 
 export function StepperWithScrollTracking() {
-	return (
-		<Stepper.Root
-			className="w-full space-y-4"
-			orientation="vertical"
-		>
-			{({ stepper }) => (
-				<>
-					<Stepper.List className="flex list-none flex-col">
-						{stepper.state.all.map((stepData, index) => {
-							const currentIndex = stepper.state.current.index;
-							const status = index < currentIndex ? "success" : index === currentIndex ? "active" : "inactive";
-							const isLast =
-								index === stepper.state.all.length - 1;
-							const data = stepData as {
-								id: string;
-								title: string;
-								description?: string;
-							};
+  return (
+    <Stepper.Root className="w-full space-y-4" orientation="vertical">
+      {({ stepper }) => (
+        <>
+          <Stepper.List className="flex list-none flex-col">
+            {stepper.state.all.map((stepData, index) => {
+              const currentIndex = stepper.state.current.index;
+              const status =
+                index < currentIndex
+                  ? "success"
+                  : index === currentIndex
+                    ? "active"
+                    : "inactive";
+              const isLast = index === stepper.state.all.length - 1;
+              const data = stepData as {
+                id: string;
+                title: string;
+                description?: string;
+              };
 
-							return (
-								<React.Fragment key={stepData.id}>
-									<Stepper.Item
-										step={stepData.id}
-										className="group peer relative flex items-center gap-2"
-									>
-										<StepperTriggerWrapper />
-										<div className="flex flex-col items-start gap-1">
-											<StepperTitleWrapper
-												title={data.title}
-											/>
-											<StepperDescriptionWrapper
-												description={
-													data.description
-												}
-											/>
-										</div>
-									</Stepper.Item>
-									<div className="flex gap-4">
-										<StepperSeparatorVertical
-											status={status}
-											isLast={isLast}
-										/>
-										<div className="flex-1 ps-4 py-2">
-											<ContentWithTracking
-												id={
-													stepData
-														.id as Get.Id<
-															typeof stepperDefinition.steps
-														>
-												}
-												isActive={
-													status === "active"
-												}
-											/>
-										</div>
-									</div>
-								</React.Fragment>
-							);
-						})}
-					</Stepper.List>
-					<Stepper.Actions className="flex justify-end gap-4 sticky bottom-0 bg-background py-4">
-						{!stepper.state.isLast && (
-							<Stepper.Prev
-								render={(domProps) => (
-									<Button
-										type="button"
-										variant="secondary"
-										{...domProps}
-									>
-										Previous
-									</Button>
-								)}
-							/>
-						)}
-						{stepper.state.isLast ? (
-							<Button
-								type="button"
-								onClick={() => stepper.navigation.reset()}
-							>
-								Start Over
-							</Button>
-						) : (
-							<Stepper.Next
-								render={(domProps) => (
-									<Button type="button" {...domProps}>
-										Next
-									</Button>
-								)}
-							/>
-						)}
-					</Stepper.Actions>
-				</>
-			)}
-		</Stepper.Root>
-	);
+              return (
+                <React.Fragment key={stepData.id}>
+                  <Stepper.Item
+                    step={stepData.id}
+                    className="group peer relative flex items-center gap-2"
+                  >
+                    <StepperTriggerWrapper />
+                    <div className="flex flex-col items-start gap-1">
+                      <StepperTitleWrapper title={data.title} />
+                      <StepperDescriptionWrapper
+                        description={data.description}
+                      />
+                    </div>
+                  </Stepper.Item>
+                  <div className="flex gap-4">
+                    <StepperSeparatorVertical status={status} isLast={isLast} />
+                    <div className="flex-1 ps-4 py-2">
+                      <ContentWithTracking
+                        id={
+                          stepData.id as Get.Id<typeof stepperDefinition.steps>
+                        }
+                        isActive={status === "active"}
+                      />
+                    </div>
+                  </div>
+                </React.Fragment>
+              );
+            })}
+          </Stepper.List>
+          <Stepper.Actions className="flex justify-end gap-4 sticky bottom-0 bg-background py-4">
+            {!stepper.state.isLast && (
+              <Stepper.Prev
+                render={(domProps) => (
+                  <Button type="button" variant="secondary" {...domProps}>
+                    Previous
+                  </Button>
+                )}
+              />
+            )}
+            {stepper.state.isLast ? (
+              <Button type="button" onClick={() => stepper.navigation.reset()}>
+                Start Over
+              </Button>
+            ) : (
+              <Stepper.Next
+                render={(domProps) => (
+                  <Button type="button" {...domProps}>
+                    Next
+                  </Button>
+                )}
+              />
+            )}
+          </Stepper.Actions>
+        </>
+      )}
+    </Stepper.Root>
+  );
 }
 
 const ContentWithTracking = ({
-	id,
-	isActive,
-}: { id: Get.Id<typeof stepperDefinition.steps>; isActive: boolean }) => {
-	const ref = React.useRef<HTMLDivElement>(null);
+  id,
+  isActive,
+}: {
+  id: Get.Id<typeof stepperDefinition.steps>;
+  isActive: boolean;
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null);
 
-	React.useEffect(() => {
-		if (isActive && ref.current) {
-			ref.current.scrollIntoView({ behavior: "smooth", block: "center" });
-		}
-	}, [isActive]);
+  React.useEffect(() => {
+    if (isActive && ref.current) {
+      ref.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [isActive]);
 
-	const contentMap: Record<string, { title: string; content: string }> = {
-		introduction: {
-			title: "Welcome!",
-			content:
-				"This tutorial will guide you through the basics and advanced concepts. Take your time to understand each section before moving on.",
-		},
-		basics: {
-			title: "Fundamental Concepts",
-			content:
-				"In this section, we cover the core concepts that form the foundation of everything else. Make sure you understand these before proceeding.",
-		},
-		advanced: {
-			title: "Advanced Topics",
-			content:
-				"Now that you understand the basics, let's dive into more complex scenarios and edge cases that you might encounter.",
-		},
-		practice: {
-			title: "Hands-on Practice",
-			content:
-				"Time to apply what you've learned! Complete the exercises below to solidify your understanding.",
-		},
-		certification: {
-			title: "Congratulations!",
-			content:
-				"You've completed all the modules. Your certificate is now ready for download.",
-		},
-	};
+  const contentMap: Record<string, { title: string; content: string }> = {
+    introduction: {
+      title: "Welcome!",
+      content:
+        "This tutorial will guide you through the basics and advanced concepts. Take your time to understand each section before moving on.",
+    },
+    basics: {
+      title: "Fundamental Concepts",
+      content:
+        "In this section, we cover the core concepts that form the foundation of everything else. Make sure you understand these before proceeding.",
+    },
+    advanced: {
+      title: "Advanced Topics",
+      content:
+        "Now that you understand the basics, let's dive into more complex scenarios and edge cases that you might encounter.",
+    },
+    practice: {
+      title: "Hands-on Practice",
+      content:
+        "Time to apply what you've learned! Complete the exercises below to solidify your understanding.",
+    },
+    certification: {
+      title: "Congratulations!",
+      content:
+        "You've completed all the modules. Your certificate is now ready for download.",
+    },
+  };
 
-	const content = contentMap[id];
+  const content = contentMap[id];
 
-	return (
-		<Stepper.Content
-			step={id}
-			render={(props) => (
-				<div
-					ref={ref}
-					{...props}
-					className="min-h-[150px] rounded border bg-secondary text-secondary-foreground p-6 transition-all duration-300"
-				>
-					<p className="text-lg font-medium">{content.title}</p>
-					<p className="text-sm text-muted-foreground mt-2">
-						{content.content}
-					</p>
-				</div>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Content
+      step={id}
+      render={(props) => (
+        <div
+          ref={ref}
+          {...props}
+          className="min-h-[150px] rounded border bg-secondary text-secondary-foreground p-6 transition-all duration-300"
+        >
+          <p className="text-lg font-medium">{content.title}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {content.content}
+          </p>
+        </div>
+      )}
+    />
+  );
 };

--- a/apps/docs/registry/base-ui/blocks/stepper-with-variants/components/stepper-with-variants.tsx
+++ b/apps/docs/registry/base-ui/blocks/stepper-with-variants/components/stepper-with-variants.tsx
@@ -1,391 +1,365 @@
 "use client";
 
-import { defineStepper, Get } from "@stepperize/react";
-import { StepStatus, useStepItemContext } from "@stepperize/react/primitives";
-import * as React from "react";
+import { defineStepper, type Get } from "@stepperize/react";
+import {
+  type StepStatus,
+  useStepItemContext,
+} from "@stepperize/react/primitives";
+import React from "react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/registry/base-ui/ui/button";
 import { Label } from "@/registry/base-ui/ui/label";
-import {
-	RadioGroup,
-	RadioGroupItem,
-} from "@/registry/base-ui/ui/radio-group";
+import { RadioGroup, RadioGroupItem } from "@/registry/base-ui/ui/radio-group";
 
 type Orientation = "horizontal" | "vertical";
 type LabelOrientation = "horizontal" | "vertical";
 
 const { Stepper, ...stepperDefinition } = defineStepper(
-	{
-		id: "step-1",
-		title: "Step 1",
-		description: "First step description",
-	},
-	{
-		id: "step-2",
-		title: "Step 2",
-		description: "Second step description",
-	},
-	{
-		id: "step-3",
-		title: "Step 3",
-		description: "Third step description",
-	}
+  {
+    id: "step-1",
+    title: "Step 1",
+    description: "First step description",
+  },
+  {
+    id: "step-2",
+    title: "Step 2",
+    description: "Second step description",
+  },
+  {
+    id: "step-3",
+    title: "Step 3",
+    description: "Third step description",
+  },
 );
 
 const StepperTriggerWrapper = () => {
-	const item = useStepItemContext();
-	const isInactive = item.status === "inactive";
+  const item = useStepItemContext();
+  const isInactive = item.status === "inactive";
 
-	return (
-		<Stepper.Trigger
-			render={(domProps) => (
-				<Button
-					className="rounded-full"
-					variant={isInactive ? "secondary" : "default"}
-					size="icon"
-					{...domProps}
-				>
-					<Stepper.Indicator>
-					{item.index + 1}
-				</Stepper.Indicator>
-				</Button>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Trigger
+      render={(domProps) => (
+        <Button
+          className="rounded-full"
+          variant={isInactive ? "secondary" : "default"}
+          size="icon"
+          {...domProps}
+        >
+          <Stepper.Indicator>{item.index + 1}</Stepper.Indicator>
+        </Button>
+      )}
+    />
+  );
 };
 
 const StepperTitleWrapper = ({ title }: { title: string }) => {
-	return (
-		<Stepper.Title
-			render={(domProps) => (
-				<h4 className="text-sm font-medium" {...domProps}>
-					{title}
-				</h4>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Title
+      render={(domProps) => (
+        <h4 className="text-sm font-medium" {...domProps}>
+          {title}
+        </h4>
+      )}
+    />
+  );
 };
 
 const StepperDescriptionWrapper = ({
-	description,
-}: { description?: string }) => {
-	if (!description) return null;
-	return (
-		<Stepper.Description
-			render={(domProps) => (
-				<p className="text-xs text-muted-foreground" {...domProps}>
-					{description}
-				</p>
-			)}
-		/>
-	);
+  description,
+}: {
+  description?: string;
+}) => {
+  if (!description) return null;
+  return (
+    <Stepper.Description
+      render={(domProps) => (
+        <p className="text-xs text-muted-foreground" {...domProps}>
+          {description}
+        </p>
+      )}
+    />
+  );
 };
 
 const StepperSeparator = ({
-	status,
-	isLast,
-	orientation,
-	labelOrientation,
+  status,
+  isLast,
+  orientation,
+  labelOrientation,
 }: {
-	status: StepStatus;
-	isLast: boolean;
-	orientation: Orientation;
-	labelOrientation: LabelOrientation;
+  status: StepStatus;
+  isLast: boolean;
+  orientation: Orientation;
+  labelOrientation: LabelOrientation;
 }) => {
-	if (isLast) return null;
+  if (isLast) return null;
 
-	const isVerticalLabel =
-		orientation === "horizontal" && labelOrientation === "vertical";
+  const isVerticalLabel =
+    orientation === "horizontal" && labelOrientation === "vertical";
 
-	return (
-		<Stepper.Separator
-			orientation={orientation}
-			data-status={status}
-			className={cn(
-				"bg-muted data-[status=success]:bg-primary data-[disabled]:opacity-50 transition-all duration-300 ease-in-out",
-				orientation === "horizontal" && "self-center h-0.5 min-w-4 flex-1",
-				orientation === "vertical" && "w-0.5 h-full",
-				isVerticalLabel &&
-					"absolute left-[calc(50%+30px)] right-[calc(-50%+20px)] top-5 block shrink-0",
-			)}
-		/>
-	);
+  return (
+    <Stepper.Separator
+      orientation={orientation}
+      data-status={status}
+      className={cn(
+        "bg-muted data-[status=success]:bg-primary data-[disabled]:opacity-50 transition-all duration-300 ease-in-out",
+        orientation === "horizontal" && "self-center h-0.5 min-w-4 flex-1",
+        orientation === "vertical" && "w-0.5 h-full",
+        isVerticalLabel &&
+          "absolute left-[calc(50%+30px)] right-[calc(-50%+20px)] top-5 block shrink-0",
+      )}
+    />
+  );
 };
 
 export function StepperWithVariants() {
-	const [orientation, setOrientation] =
-		React.useState<Orientation>("horizontal");
-	const [labelOrientation, setLabelOrientation] =
-		React.useState<LabelOrientation>("horizontal");
+  const [orientation, setOrientation] =
+    React.useState<Orientation>("horizontal");
+  const [labelOrientation, setLabelOrientation] =
+    React.useState<LabelOrientation>("horizontal");
 
-	const isVerticalLabel =
-		orientation === "horizontal" && labelOrientation === "vertical";
+  const isVerticalLabel =
+    orientation === "horizontal" && labelOrientation === "vertical";
 
-	return (
-		<div className="w-full space-y-8">
-			{/* Controls */}
-			<div className="flex flex-wrap gap-8 p-4 rounded-lg border bg-muted/50 w-max">
-				<div className="space-y-2">
-					<Label className="text-sm font-medium">Orientation</Label>
-					<RadioGroup
-						value={orientation}
-						onValueChange={(value) =>
-							setOrientation(value as Orientation)
-						}
-						className="flex gap-4"
-					>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem value="horizontal" id="h-orient" />
-							<Label htmlFor="h-orient" className="font-normal">
-								Horizontal
-							</Label>
-						</div>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem value="vertical" id="v-orient" />
-							<Label htmlFor="v-orient" className="font-normal">
-								Vertical
-							</Label>
-						</div>
-					</RadioGroup>
-				</div>
+  return (
+    <div className="w-full space-y-8">
+      {/* Controls */}
+      <div className="flex flex-wrap gap-8 p-4 rounded-lg border bg-muted/50 w-max">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Orientation</Label>
+          <RadioGroup
+            value={orientation}
+            onValueChange={(value) => setOrientation(value as Orientation)}
+            className="flex gap-4"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="horizontal" id="h-orient" />
+              <Label htmlFor="h-orient" className="font-normal">
+                Horizontal
+              </Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="vertical" id="v-orient" />
+              <Label htmlFor="v-orient" className="font-normal">
+                Vertical
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
 
-				<div className="space-y-2">
-					<Label
-						className={cn(
-							"text-sm font-medium",
-							orientation === "vertical" && "text-muted-foreground",
-						)}
-					>
-						Label Orientation
-					</Label>
-					<RadioGroup
-						value={labelOrientation}
-						onValueChange={(value) =>
-							setLabelOrientation(value as LabelOrientation)
-						}
-						disabled={orientation === "vertical"}
-						className="flex gap-4"
-					>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem
-								value="horizontal"
-								id="h-label"
-							/>
-							<Label
-								htmlFor="h-label"
-								className={cn(
-									"font-normal",
-									orientation === "vertical" && "text-muted-foreground",
-								)}
-							>
-								Horizontal
-							</Label>
-						</div>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem value="vertical" id="v-label" />
-							<Label
-								htmlFor="v-label"
-								className={cn(
-									"font-normal",
-									orientation === "vertical" && "text-muted-foreground",
-								)}
-							>
-								Vertical
-							</Label>
-						</div>
-					</RadioGroup>
-				</div>
-			</div>
+        <div className="space-y-2">
+          <Label
+            className={cn(
+              "text-sm font-medium",
+              orientation === "vertical" && "text-muted-foreground",
+            )}
+          >
+            Label Orientation
+          </Label>
+          <RadioGroup
+            value={labelOrientation}
+            onValueChange={(value) =>
+              setLabelOrientation(value as LabelOrientation)
+            }
+            disabled={orientation === "vertical"}
+            className="flex gap-4"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="horizontal" id="h-label" />
+              <Label
+                htmlFor="h-label"
+                className={cn(
+                  "font-normal",
+                  orientation === "vertical" && "text-muted-foreground",
+                )}
+              >
+                Horizontal
+              </Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="vertical" id="v-label" />
+              <Label
+                htmlFor="v-label"
+                className={cn(
+                  "font-normal",
+                  orientation === "vertical" && "text-muted-foreground",
+                )}
+              >
+                Vertical
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+      </div>
 
-			{/* Stepper */}
-			<Stepper.Root
-				className="w-full space-y-4"
-				orientation={orientation}
-			>
-				{({ stepper }) => (
-					<>
-						<Stepper.List
-							className={cn(
-								"flex list-none gap-2",
-								orientation === "horizontal" &&
-									"flex-row items-center justify-between",
-								orientation === "vertical" && "flex-col",
-							)}
-						>
-{stepper.state.all.map((stepData, index) => {
-							const currentIndex = stepper.state.current.index;
-							const status = index < currentIndex ? "success" : index === currentIndex ? "active" : "inactive";
-							const isLast = index === stepper.state.all.length - 1;
+      {/* Stepper */}
+      <Stepper.Root className="w-full space-y-4" orientation={orientation}>
+        {({ stepper }) => (
+          <>
+            <Stepper.List
+              className={cn(
+                "flex list-none gap-2",
+                orientation === "horizontal" &&
+                  "flex-row items-center justify-between",
+                orientation === "vertical" && "flex-col",
+              )}
+            >
+              {stepper.state.all.map((stepData, index) => {
+                const currentIndex = stepper.state.current.index;
+                const status =
+                  index < currentIndex
+                    ? "success"
+                    : index === currentIndex
+                      ? "active"
+                      : "inactive";
+                const isLast = index === stepper.state.all.length - 1;
 
-								if (orientation === "vertical") {
-									return (
-										<React.Fragment key={stepData.id}>
-											<Stepper.Item
-												step={stepData.id}
-												className="group peer relative flex shrink-0 items-center gap-2"
-											>
-												<StepperTriggerWrapper />
-												<div className="flex flex-col items-start gap-1">
-													<StepperTitleWrapper
-														title={stepData.title}
-													/>
-													<StepperDescriptionWrapper
-														description={
-															stepData.description
-														}
-													/>
-												</div>
-											</Stepper.Item>
-											<div className="flex gap-4">
-												{!isLast && (
-													<div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
-														<StepperSeparator
-															status={status}
-															isLast={isLast}
-															orientation={
-																orientation
-															}
-															labelOrientation={
-																labelOrientation
-															}
-														/>
-													</div>
-												)}
-												<div className="my-3 flex-1 ps-4">
-													<Content
-														id={
-															stepData
-																.id as Get.Id<
-																typeof stepperDefinition.steps
-															>
-														}
-													/>
-												</div>
-											</div>
-										</React.Fragment>
-									);
-								}
+                if (orientation === "vertical") {
+                  return (
+                    <React.Fragment key={stepData.id}>
+                      <Stepper.Item
+                        step={stepData.id}
+                        className="group peer relative flex shrink-0 items-center gap-2"
+                      >
+                        <StepperTriggerWrapper />
+                        <div className="flex flex-col items-start gap-1">
+                          <StepperTitleWrapper title={stepData.title} />
+                          <StepperDescriptionWrapper
+                            description={stepData.description}
+                          />
+                        </div>
+                      </Stepper.Item>
+                      <div className="flex gap-4">
+                        {!isLast && (
+                          <div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
+                            <StepperSeparator
+                              status={status}
+                              isLast={isLast}
+                              orientation={orientation}
+                              labelOrientation={labelOrientation}
+                            />
+                          </div>
+                        )}
+                        <div className="my-3 flex-1 ps-4">
+                          <Content
+                            id={
+                              stepData.id as Get.Id<
+                                typeof stepperDefinition.steps
+                              >
+                            }
+                          />
+                        </div>
+                      </div>
+                    </React.Fragment>
+                  );
+                }
 
-								if (isVerticalLabel) {
-									return (
-										<Stepper.Item
-											key={stepData.id}
-											step={stepData.id}
-											className="group peer relative flex w-full flex-col items-center justify-center gap-2"
-										>
-											<StepperTriggerWrapper />
-											<StepperSeparator
-												status={status}
-												isLast={isLast}
-												orientation={orientation}
-												labelOrientation={
-													labelOrientation
-												}
-											/>
-											<div className="flex flex-col items-center text-center gap-1">
-												<StepperTitleWrapper
-													title={stepData.title}
-												/>
-												<StepperDescriptionWrapper
-													description={
-														stepData.description
-													}
-												/>
-											</div>
-										</Stepper.Item>
-									);
-								}
+                if (isVerticalLabel) {
+                  return (
+                    <Stepper.Item
+                      key={stepData.id}
+                      step={stepData.id}
+                      className="group peer relative flex w-full flex-col items-center justify-center gap-2"
+                    >
+                      <StepperTriggerWrapper />
+                      <StepperSeparator
+                        status={status}
+                        isLast={isLast}
+                        orientation={orientation}
+                        labelOrientation={labelOrientation}
+                      />
+                      <div className="flex flex-col items-center text-center gap-1">
+                        <StepperTitleWrapper title={stepData.title} />
+                        <StepperDescriptionWrapper
+                          description={stepData.description}
+                        />
+                      </div>
+                    </Stepper.Item>
+                  );
+                }
 
-								// Horizontal with horizontal labels
-								return (
-									<React.Fragment key={stepData.id}>
-										<Stepper.Item
-											key={stepData.id}
-											step={stepData.id}
-											className="group peer relative flex shrink-0 items-center gap-2"
-										>
-											<StepperTriggerWrapper />
-											<div className="flex flex-col items-start gap-1">
-												<StepperTitleWrapper
-													title={stepData.title}
-												/>
-												<StepperDescriptionWrapper
-													description={
-														stepData.description
-													}
-												/>
-											</div>
-										</Stepper.Item>
-										<StepperSeparator
-											key={`separator-${stepData.id}`}
-											status={status}
-											isLast={isLast}
-											orientation={orientation}
-											labelOrientation={labelOrientation}
-										/>
-									</React.Fragment>
-								);
-							})}
-						</Stepper.List>
+                // Horizontal with horizontal labels
+                return (
+                  <React.Fragment key={stepData.id}>
+                    <Stepper.Item
+                      key={stepData.id}
+                      step={stepData.id}
+                      className="group peer relative flex shrink-0 items-center gap-2"
+                    >
+                      <StepperTriggerWrapper />
+                      <div className="flex flex-col items-start gap-1">
+                        <StepperTitleWrapper title={stepData.title} />
+                        <StepperDescriptionWrapper
+                          description={stepData.description}
+                        />
+                      </div>
+                    </Stepper.Item>
+                    <StepperSeparator
+                      key={`separator-${stepData.id}`}
+                      status={status}
+                      isLast={isLast}
+                      orientation={orientation}
+                      labelOrientation={labelOrientation}
+                    />
+                  </React.Fragment>
+                );
+              })}
+            </Stepper.List>
 
-						{orientation === "horizontal" &&
-							stepper.flow.switch({
-								"step-1": (data) => <Content id={data.id} />,
-								"step-2": (data) => <Content id={data.id} />,
-								"step-3": (data) => <Content id={data.id} />,
-							})}
+            {orientation === "horizontal" &&
+              stepper.flow.switch({
+                "step-1": (data) => <Content id={data.id} />,
+                "step-2": (data) => <Content id={data.id} />,
+                "step-3": (data) => <Content id={data.id} />,
+              })}
 
-						<Stepper.Actions className="flex justify-end gap-4">
-							{!stepper.state.isLast && (
-								<Stepper.Prev
-									render={(domProps) => (
-										<Button
-											type="button"
-											variant="secondary"
-											{...domProps}
-										>
-											Previous
-										</Button>
-									)}
-								/>
-							)}
-							{stepper.state.isLast ? (
-								<Button
-									type="button"
-									onClick={() => stepper.navigation.reset()}
-								>
-									Reset
-								</Button>
-							) : (
-								<Stepper.Next
-									render={(domProps) => (
-										<Button type="button" {...domProps}>
-											Next
-										</Button>
-									)}
-								/>
-							)}
-						</Stepper.Actions>
-					</>
-				)}
-			</Stepper.Root>
-		</div>
-	);
+            <Stepper.Actions className="flex justify-end gap-4">
+              {!stepper.state.isLast && (
+                <Stepper.Prev
+                  render={(domProps) => (
+                    <Button type="button" variant="secondary" {...domProps}>
+                      Previous
+                    </Button>
+                  )}
+                />
+              )}
+              {stepper.state.isLast ? (
+                <Button
+                  type="button"
+                  onClick={() => stepper.navigation.reset()}
+                >
+                  Reset
+                </Button>
+              ) : (
+                <Stepper.Next
+                  render={(domProps) => (
+                    <Button type="button" {...domProps}>
+                      Next
+                    </Button>
+                  )}
+                />
+              )}
+            </Stepper.Actions>
+          </>
+        )}
+      </Stepper.Root>
+    </div>
+  );
 }
 
 const Content = ({ id }: { id: Get.Id<typeof stepperDefinition.steps> }) => {
-	return (
-		<Stepper.Content
-			step={id}
-			render={(props) => (
-				<div
-					{...props}
-					className="h-[150px] content-center rounded border bg-secondary text-secondary-foreground p-8"
-				>
-					<p className="text-xl font-normal">Content for {id}</p>
-				</div>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Content
+      step={id}
+      render={(props) => (
+        <div
+          {...props}
+          className="h-[150px] content-center rounded border bg-secondary text-secondary-foreground p-8"
+        >
+          <p className="text-xl font-normal">Content for {id}</p>
+        </div>
+      )}
+    />
+  );
 };

--- a/apps/docs/registry/base-ui/ui/input.tsx
+++ b/apps/docs/registry/base-ui/ui/input.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Input as InputPrimitive } from "@base-ui/react/input"
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -10,11 +10,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/apps/docs/registry/base-ui/ui/label.tsx
+++ b/apps/docs/registry/base-ui/ui/label.tsx
@@ -1,8 +1,8 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({ className, ...props }: React.ComponentProps<"label">) {
   return (
@@ -10,11 +10,11 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
       data-slot="label"
       className={cn(
         "gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/apps/docs/registry/radix-ui/blocks/stepper-with-scroll-tracking/components/stepper-with-scroll-tracking.tsx
+++ b/apps/docs/registry/radix-ui/blocks/stepper-with-scroll-tracking/components/stepper-with-scroll-tracking.tsx
@@ -1,260 +1,251 @@
 "use client";
 
-import { defineStepper, Get } from "@stepperize/react";
-import { StepStatus, useStepItemContext } from "@stepperize/react/primitives";
-import * as React from "react";
+import { defineStepper, type Get } from "@stepperize/react";
+import {
+  type StepStatus,
+  useStepItemContext,
+} from "@stepperize/react/primitives";
+import React from "react";
 
 import { Button } from "@/registry/radix-ui/ui/button";
 
 const { Stepper, ...stepperDefinition } = defineStepper(
-	{
-		id: "introduction",
-		title: "Introduction",
-		description: "Welcome to the tutorial",
-	},
-	{
-		id: "basics",
-		title: "Basics",
-		description: "Learn the fundamentals",
-	},
-	{
-		id: "advanced",
-		title: "Advanced",
-		description: "Deep dive into advanced topics",
-	},
-	{
-		id: "practice",
-		title: "Practice",
-		description: "Apply what you learned",
-	},
-	{
-		id: "certification",
-		title: "Certification",
-		description: "Get your certificate",
-	}
+  {
+    id: "introduction",
+    title: "Introduction",
+    description: "Welcome to the tutorial",
+  },
+  {
+    id: "basics",
+    title: "Basics",
+    description: "Learn the fundamentals",
+  },
+  {
+    id: "advanced",
+    title: "Advanced",
+    description: "Deep dive into advanced topics",
+  },
+  {
+    id: "practice",
+    title: "Practice",
+    description: "Apply what you learned",
+  },
+  {
+    id: "certification",
+    title: "Certification",
+    description: "Get your certificate",
+  },
 );
 
 const StepperTriggerWrapper = () => {
-	const item = useStepItemContext();
-	const isInactive = item.status === "inactive";
+  const item = useStepItemContext();
+  const isInactive = item.status === "inactive";
 
-	return (
-		<Stepper.Trigger
-			render={(domProps) => (
-				<Button
-					className="rounded-full"
-					variant={isInactive ? "secondary" : "default"}
-					size="icon"
-					{...domProps}
-				>
-					<Stepper.Indicator>
-						{item.index + 1}
-					</Stepper.Indicator>
-				</Button>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Trigger
+      render={(domProps) => (
+        <Button
+          className="rounded-full"
+          variant={isInactive ? "secondary" : "default"}
+          size="icon"
+          {...domProps}
+        >
+          <Stepper.Indicator>{item.index + 1}</Stepper.Indicator>
+        </Button>
+      )}
+    />
+  );
 };
 
 const StepperTitleWrapper = ({ title }: { title: string }) => {
-	return (
-		<Stepper.Title
-			render={(domProps) => (
-				<h4 className="text-base font-medium" {...domProps}>
-					{title}
-				</h4>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Title
+      render={(domProps) => (
+        <h4 className="text-base font-medium" {...domProps}>
+          {title}
+        </h4>
+      )}
+    />
+  );
 };
 
 const StepperDescriptionWrapper = ({
-	description,
-}: { description?: string }) => {
-	if (!description) return null;
-	return (
-		<Stepper.Description
-			render={(domProps) => (
-				<p className="text-sm text-muted-foreground" {...domProps}>
-					{description}
-				</p>
-			)}
-		/>
-	);
+  description,
+}: {
+  description?: string;
+}) => {
+  if (!description) return null;
+  return (
+    <Stepper.Description
+      render={(domProps) => (
+        <p className="text-sm text-muted-foreground" {...domProps}>
+          {description}
+        </p>
+      )}
+    />
+  );
 };
 
 const StepperSeparatorVertical = ({
-	status,
-	isLast,
-}: { status: StepStatus; isLast: boolean }) => {
-	if (isLast) return null;
+  status,
+  isLast,
+}: {
+  status: StepStatus;
+  isLast: boolean;
+}) => {
+  if (isLast) return null;
 
-	return (
-		<div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
-			<Stepper.Separator
-				orientation="vertical"
-				data-status={status}
-				className="w-0.5 h-full bg-muted data-[status=success]:bg-primary transition-all duration-300 ease-in-out"
-			/>
-		</div>
-	);
+  return (
+    <div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
+      <Stepper.Separator
+        orientation="vertical"
+        data-status={status}
+        className="w-0.5 h-full bg-muted data-[status=success]:bg-primary transition-all duration-300 ease-in-out"
+      />
+    </div>
+  );
 };
 
 export function StepperWithScrollTracking() {
-	return (
-		<Stepper.Root
-			className="w-full space-y-4"
-			orientation="vertical"
-		>
-			{({ stepper }) => (
-				<>
-					<Stepper.List className="flex list-none flex-col">
-						{stepper.state.all.map((stepData, index) => {
-							const currentIndex = stepper.state.current.index;
-							const status = index < currentIndex ? "success" : index === currentIndex ? "active" : "inactive";
-							const isLast =
-								index === stepper.state.all.length - 1;
-							const data = stepData as {
-								id: string;
-								title: string;
-								description?: string;
-							};
+  return (
+    <Stepper.Root className="w-full space-y-4" orientation="vertical">
+      {({ stepper }) => (
+        <>
+          <Stepper.List className="flex list-none flex-col">
+            {stepper.state.all.map((stepData, index) => {
+              const currentIndex = stepper.state.current.index;
+              const status =
+                index < currentIndex
+                  ? "success"
+                  : index === currentIndex
+                    ? "active"
+                    : "inactive";
+              const isLast = index === stepper.state.all.length - 1;
+              const data = stepData as {
+                id: string;
+                title: string;
+                description?: string;
+              };
 
-							return (
-								<React.Fragment key={stepData.id}>
-									<Stepper.Item
-										step={stepData.id}
-										className="group peer relative flex items-center gap-2"
-									>
-										<StepperTriggerWrapper />
-										<div className="flex flex-col items-start gap-1">
-											<StepperTitleWrapper
-												title={data.title}
-											/>
-											<StepperDescriptionWrapper
-												description={
-													data.description
-												}
-											/>
-										</div>
-									</Stepper.Item>
-									<div className="flex gap-4">
-										<StepperSeparatorVertical
-											status={status}
-											isLast={isLast}
-										/>
-										<div className="flex-1 ps-4 py-2">
-											<ContentWithTracking
-												id={
-													stepData
-														.id as Get.Id<
-															typeof stepperDefinition.steps
-														>
-												}
-												isActive={
-													status === "active"
-												}
-											/>
-										</div>
-									</div>
-								</React.Fragment>
-							);
-						})}
-					</Stepper.List>
-					<Stepper.Actions className="flex justify-end gap-4 sticky bottom-0 bg-background py-4">
-						{!stepper.state.isLast && (
-							<Stepper.Prev
-								render={(domProps) => (
-									<Button
-										type="button"
-										variant="secondary"
-										{...domProps}
-									>
-										Previous
-									</Button>
-								)}
-							/>
-						)}
-						{stepper.state.isLast ? (
-							<Button
-								type="button"
-								onClick={() => stepper.navigation.reset()}
-							>
-								Start Over
-							</Button>
-						) : (
-							<Stepper.Next
-								render={(domProps) => (
-									<Button type="button" {...domProps}>
-										Next
-									</Button>
-								)}
-							/>
-						)}
-					</Stepper.Actions>
-				</>
-			)}
-		</Stepper.Root>
-	);
+              return (
+                <React.Fragment key={stepData.id}>
+                  <Stepper.Item
+                    step={stepData.id}
+                    className="group peer relative flex items-center gap-2"
+                  >
+                    <StepperTriggerWrapper />
+                    <div className="flex flex-col items-start gap-1">
+                      <StepperTitleWrapper title={data.title} />
+                      <StepperDescriptionWrapper
+                        description={data.description}
+                      />
+                    </div>
+                  </Stepper.Item>
+                  <div className="flex gap-4">
+                    <StepperSeparatorVertical status={status} isLast={isLast} />
+                    <div className="flex-1 ps-4 py-2">
+                      <ContentWithTracking
+                        id={
+                          stepData.id as Get.Id<typeof stepperDefinition.steps>
+                        }
+                        isActive={status === "active"}
+                      />
+                    </div>
+                  </div>
+                </React.Fragment>
+              );
+            })}
+          </Stepper.List>
+          <Stepper.Actions className="flex justify-end gap-4 sticky bottom-0 bg-background py-4">
+            {!stepper.state.isLast && (
+              <Stepper.Prev
+                render={(domProps) => (
+                  <Button type="button" variant="secondary" {...domProps}>
+                    Previous
+                  </Button>
+                )}
+              />
+            )}
+            {stepper.state.isLast ? (
+              <Button type="button" onClick={() => stepper.navigation.reset()}>
+                Start Over
+              </Button>
+            ) : (
+              <Stepper.Next
+                render={(domProps) => (
+                  <Button type="button" {...domProps}>
+                    Next
+                  </Button>
+                )}
+              />
+            )}
+          </Stepper.Actions>
+        </>
+      )}
+    </Stepper.Root>
+  );
 }
 
 const ContentWithTracking = ({
-	id,
-	isActive,
-}: { id: Get.Id<typeof stepperDefinition.steps>; isActive: boolean }) => {
-	const ref = React.useRef<HTMLDivElement>(null);
+  id,
+  isActive,
+}: {
+  id: Get.Id<typeof stepperDefinition.steps>;
+  isActive: boolean;
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null);
 
-	React.useEffect(() => {
-		if (isActive && ref.current) {
-			ref.current.scrollIntoView({ behavior: "smooth", block: "center" });
-		}
-	}, [isActive]);
+  React.useEffect(() => {
+    if (isActive && ref.current) {
+      ref.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [isActive]);
 
-	const contentMap: Record<string, { title: string; content: string }> = {
-		introduction: {
-			title: "Welcome!",
-			content:
-				"This tutorial will guide you through the basics and advanced concepts. Take your time to understand each section before moving on.",
-		},
-		basics: {
-			title: "Fundamental Concepts",
-			content:
-				"In this section, we cover the core concepts that form the foundation of everything else. Make sure you understand these before proceeding.",
-		},
-		advanced: {
-			title: "Advanced Topics",
-			content:
-				"Now that you understand the basics, let's dive into more complex scenarios and edge cases that you might encounter.",
-		},
-		practice: {
-			title: "Hands-on Practice",
-			content:
-				"Time to apply what you've learned! Complete the exercises below to solidify your understanding.",
-		},
-		certification: {
-			title: "Congratulations!",
-			content:
-				"You've completed all the modules. Your certificate is now ready for download.",
-		},
-	};
+  const contentMap: Record<string, { title: string; content: string }> = {
+    introduction: {
+      title: "Welcome!",
+      content:
+        "This tutorial will guide you through the basics and advanced concepts. Take your time to understand each section before moving on.",
+    },
+    basics: {
+      title: "Fundamental Concepts",
+      content:
+        "In this section, we cover the core concepts that form the foundation of everything else. Make sure you understand these before proceeding.",
+    },
+    advanced: {
+      title: "Advanced Topics",
+      content:
+        "Now that you understand the basics, let's dive into more complex scenarios and edge cases that you might encounter.",
+    },
+    practice: {
+      title: "Hands-on Practice",
+      content:
+        "Time to apply what you've learned! Complete the exercises below to solidify your understanding.",
+    },
+    certification: {
+      title: "Congratulations!",
+      content:
+        "You've completed all the modules. Your certificate is now ready for download.",
+    },
+  };
 
-	const content = contentMap[id];
+  const content = contentMap[id];
 
-	return (
-		<Stepper.Content
-			step={id}
-			render={(props) => (
-				<div
-					ref={ref}
-					{...props}
-					className="min-h-[150px] rounded border bg-secondary text-secondary-foreground p-6 transition-all duration-300"
-				>
-					<p className="text-lg font-medium">{content.title}</p>
-					<p className="text-sm text-muted-foreground mt-2">
-						{content.content}
-					</p>
-				</div>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Content
+      step={id}
+      render={(props) => (
+        <div
+          ref={ref}
+          {...props}
+          className="min-h-[150px] rounded border bg-secondary text-secondary-foreground p-6 transition-all duration-300"
+        >
+          <p className="text-lg font-medium">{content.title}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {content.content}
+          </p>
+        </div>
+      )}
+    />
+  );
 };

--- a/apps/docs/registry/radix-ui/blocks/stepper-with-variants/components/stepper-with-variants.tsx
+++ b/apps/docs/registry/radix-ui/blocks/stepper-with-variants/components/stepper-with-variants.tsx
@@ -1,391 +1,365 @@
 "use client";
 
-import { defineStepper, Get } from "@stepperize/react";
-import { StepStatus, useStepItemContext } from "@stepperize/react/primitives";
-import * as React from "react";
+import { defineStepper, type Get } from "@stepperize/react";
+import {
+  type StepStatus,
+  useStepItemContext,
+} from "@stepperize/react/primitives";
+import React from "react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/registry/radix-ui/ui/button";
 import { Label } from "@/registry/radix-ui/ui/label";
-import {
-	RadioGroup,
-	RadioGroupItem,
-} from "@/registry/radix-ui/ui/radio-group";
+import { RadioGroup, RadioGroupItem } from "@/registry/radix-ui/ui/radio-group";
 
 type Orientation = "horizontal" | "vertical";
 type LabelOrientation = "horizontal" | "vertical";
 
 const { Stepper, ...stepperDefinition } = defineStepper(
-	{
-		id: "step-1",
-		title: "Step 1",
-		description: "First step description",
-	},
-	{
-		id: "step-2",
-		title: "Step 2",
-		description: "Second step description",
-	},
-	{
-		id: "step-3",
-		title: "Step 3",
-		description: "Third step description",
-	}
+  {
+    id: "step-1",
+    title: "Step 1",
+    description: "First step description",
+  },
+  {
+    id: "step-2",
+    title: "Step 2",
+    description: "Second step description",
+  },
+  {
+    id: "step-3",
+    title: "Step 3",
+    description: "Third step description",
+  },
 );
 
 const StepperTriggerWrapper = () => {
-	const item = useStepItemContext();
-	const isInactive = item.status === "inactive";
+  const item = useStepItemContext();
+  const isInactive = item.status === "inactive";
 
-	return (
-		<Stepper.Trigger
-			render={(domProps) => (
-				<Button
-					className="rounded-full"
-					variant={isInactive ? "secondary" : "default"}
-					size="icon"
-					{...domProps}
-				>
-					<Stepper.Indicator>
-					{item.index + 1}
-				</Stepper.Indicator>
-				</Button>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Trigger
+      render={(domProps) => (
+        <Button
+          className="rounded-full"
+          variant={isInactive ? "secondary" : "default"}
+          size="icon"
+          {...domProps}
+        >
+          <Stepper.Indicator>{item.index + 1}</Stepper.Indicator>
+        </Button>
+      )}
+    />
+  );
 };
 
 const StepperTitleWrapper = ({ title }: { title: string }) => {
-	return (
-		<Stepper.Title
-			render={(domProps) => (
-				<h4 className="text-sm font-medium" {...domProps}>
-					{title}
-				</h4>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Title
+      render={(domProps) => (
+        <h4 className="text-sm font-medium" {...domProps}>
+          {title}
+        </h4>
+      )}
+    />
+  );
 };
 
 const StepperDescriptionWrapper = ({
-	description,
-}: { description?: string }) => {
-	if (!description) return null;
-	return (
-		<Stepper.Description
-			render={(domProps) => (
-				<p className="text-xs text-muted-foreground" {...domProps}>
-					{description}
-				</p>
-			)}
-		/>
-	);
+  description,
+}: {
+  description?: string;
+}) => {
+  if (!description) return null;
+  return (
+    <Stepper.Description
+      render={(domProps) => (
+        <p className="text-xs text-muted-foreground" {...domProps}>
+          {description}
+        </p>
+      )}
+    />
+  );
 };
 
 const StepperSeparator = ({
-	status,
-	isLast,
-	orientation,
-	labelOrientation,
+  status,
+  isLast,
+  orientation,
+  labelOrientation,
 }: {
-	status: StepStatus;
-	isLast: boolean;
-	orientation: Orientation;
-	labelOrientation: LabelOrientation;
+  status: StepStatus;
+  isLast: boolean;
+  orientation: Orientation;
+  labelOrientation: LabelOrientation;
 }) => {
-	if (isLast) return null;
+  if (isLast) return null;
 
-	const isVerticalLabel =
-		orientation === "horizontal" && labelOrientation === "vertical";
+  const isVerticalLabel =
+    orientation === "horizontal" && labelOrientation === "vertical";
 
-	return (
-		<Stepper.Separator
-			orientation={orientation}
-			data-status={status}
-			className={cn(
-				"bg-muted data-[status=success]:bg-primary data-[disabled]:opacity-50 transition-all duration-300 ease-in-out",
-				orientation === "horizontal" && "self-center h-0.5 min-w-4 flex-1",
-				orientation === "vertical" && "w-0.5 h-full",
-				isVerticalLabel &&
-					"absolute left-[calc(50%+30px)] right-[calc(-50%+20px)] top-5 block shrink-0",
-			)}
-		/>
-	);
+  return (
+    <Stepper.Separator
+      orientation={orientation}
+      data-status={status}
+      className={cn(
+        "bg-muted data-[status=success]:bg-primary data-[disabled]:opacity-50 transition-all duration-300 ease-in-out",
+        orientation === "horizontal" && "self-center h-0.5 min-w-4 flex-1",
+        orientation === "vertical" && "w-0.5 h-full",
+        isVerticalLabel &&
+          "absolute left-[calc(50%+30px)] right-[calc(-50%+20px)] top-5 block shrink-0",
+      )}
+    />
+  );
 };
 
 export function StepperWithVariants() {
-	const [orientation, setOrientation] =
-		React.useState<Orientation>("horizontal");
-	const [labelOrientation, setLabelOrientation] =
-		React.useState<LabelOrientation>("horizontal");
+  const [orientation, setOrientation] =
+    React.useState<Orientation>("horizontal");
+  const [labelOrientation, setLabelOrientation] =
+    React.useState<LabelOrientation>("horizontal");
 
-	const isVerticalLabel =
-		orientation === "horizontal" && labelOrientation === "vertical";
+  const isVerticalLabel =
+    orientation === "horizontal" && labelOrientation === "vertical";
 
-	return (
-		<div className="w-full space-y-8">
-			{/* Controls */}
-			<div className="flex flex-wrap gap-8 p-4 rounded-lg border bg-muted/50 w-max">
-				<div className="space-y-2">
-					<Label className="text-sm font-medium">Orientation</Label>
-					<RadioGroup
-						value={orientation}
-						onValueChange={(value) =>
-							setOrientation(value as Orientation)
-						}
-						className="flex gap-4"
-					>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem value="horizontal" id="h-orient" />
-							<Label htmlFor="h-orient" className="font-normal">
-								Horizontal
-							</Label>
-						</div>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem value="vertical" id="v-orient" />
-							<Label htmlFor="v-orient" className="font-normal">
-								Vertical
-							</Label>
-						</div>
-					</RadioGroup>
-				</div>
+  return (
+    <div className="w-full space-y-8">
+      {/* Controls */}
+      <div className="flex flex-wrap gap-8 p-4 rounded-lg border bg-muted/50 w-max">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Orientation</Label>
+          <RadioGroup
+            value={orientation}
+            onValueChange={(value) => setOrientation(value as Orientation)}
+            className="flex gap-4"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="horizontal" id="h-orient" />
+              <Label htmlFor="h-orient" className="font-normal">
+                Horizontal
+              </Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="vertical" id="v-orient" />
+              <Label htmlFor="v-orient" className="font-normal">
+                Vertical
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
 
-				<div className="space-y-2">
-					<Label
-						className={cn(
-							"text-sm font-medium",
-							orientation === "vertical" && "text-muted-foreground",
-						)}
-					>
-						Label Orientation
-					</Label>
-					<RadioGroup
-						value={labelOrientation}
-						onValueChange={(value) =>
-							setLabelOrientation(value as LabelOrientation)
-						}
-						disabled={orientation === "vertical"}
-						className="flex gap-4"
-					>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem
-								value="horizontal"
-								id="h-label"
-							/>
-							<Label
-								htmlFor="h-label"
-								className={cn(
-									"font-normal",
-									orientation === "vertical" && "text-muted-foreground",
-								)}
-							>
-								Horizontal
-							</Label>
-						</div>
-						<div className="flex items-center space-x-2">
-							<RadioGroupItem value="vertical" id="v-label" />
-							<Label
-								htmlFor="v-label"
-								className={cn(
-									"font-normal",
-									orientation === "vertical" && "text-muted-foreground",
-								)}
-							>
-								Vertical
-							</Label>
-						</div>
-					</RadioGroup>
-				</div>
-			</div>
+        <div className="space-y-2">
+          <Label
+            className={cn(
+              "text-sm font-medium",
+              orientation === "vertical" && "text-muted-foreground",
+            )}
+          >
+            Label Orientation
+          </Label>
+          <RadioGroup
+            value={labelOrientation}
+            onValueChange={(value) =>
+              setLabelOrientation(value as LabelOrientation)
+            }
+            disabled={orientation === "vertical"}
+            className="flex gap-4"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="horizontal" id="h-label" />
+              <Label
+                htmlFor="h-label"
+                className={cn(
+                  "font-normal",
+                  orientation === "vertical" && "text-muted-foreground",
+                )}
+              >
+                Horizontal
+              </Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="vertical" id="v-label" />
+              <Label
+                htmlFor="v-label"
+                className={cn(
+                  "font-normal",
+                  orientation === "vertical" && "text-muted-foreground",
+                )}
+              >
+                Vertical
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+      </div>
 
-			{/* Stepper */}
-			<Stepper.Root
-				className="w-full space-y-4"
-				orientation={orientation}
-			>
-				{({ stepper }) => (
-					<>
-						<Stepper.List
-							className={cn(
-								"flex list-none gap-2",
-								orientation === "horizontal" &&
-									"flex-row items-center justify-between",
-								orientation === "vertical" && "flex-col",
-							)}
-						>
-{stepper.state.all.map((stepData, index) => {
-							const currentIndex = stepper.state.current.index;
-							const status = index < currentIndex ? "success" : index === currentIndex ? "active" : "inactive";
-							const isLast = index === stepper.state.all.length - 1;
+      {/* Stepper */}
+      <Stepper.Root className="w-full space-y-4" orientation={orientation}>
+        {({ stepper }) => (
+          <>
+            <Stepper.List
+              className={cn(
+                "flex list-none gap-2",
+                orientation === "horizontal" &&
+                  "flex-row items-center justify-between",
+                orientation === "vertical" && "flex-col",
+              )}
+            >
+              {stepper.state.all.map((stepData, index) => {
+                const currentIndex = stepper.state.current.index;
+                const status =
+                  index < currentIndex
+                    ? "success"
+                    : index === currentIndex
+                      ? "active"
+                      : "inactive";
+                const isLast = index === stepper.state.all.length - 1;
 
-								if (orientation === "vertical") {
-									return (
-										<React.Fragment key={stepData.id}>
-											<Stepper.Item
-												step={stepData.id}
-												className="group peer relative flex shrink-0 items-center gap-2"
-											>
-												<StepperTriggerWrapper />
-												<div className="flex flex-col items-start gap-1">
-													<StepperTitleWrapper
-														title={stepData.title}
-													/>
-													<StepperDescriptionWrapper
-														description={
-															stepData.description
-														}
-													/>
-												</div>
-											</Stepper.Item>
-											<div className="flex gap-4">
-												{!isLast && (
-													<div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
-														<StepperSeparator
-															status={status}
-															isLast={isLast}
-															orientation={
-																orientation
-															}
-															labelOrientation={
-																labelOrientation
-															}
-														/>
-													</div>
-												)}
-												<div className="my-3 flex-1 ps-4">
-													<Content
-														id={
-															stepData
-																.id as Get.Id<
-																typeof stepperDefinition.steps
-															>
-														}
-													/>
-												</div>
-											</div>
-										</React.Fragment>
-									);
-								}
+                if (orientation === "vertical") {
+                  return (
+                    <React.Fragment key={stepData.id}>
+                      <Stepper.Item
+                        step={stepData.id}
+                        className="group peer relative flex shrink-0 items-center gap-2"
+                      >
+                        <StepperTriggerWrapper />
+                        <div className="flex flex-col items-start gap-1">
+                          <StepperTitleWrapper title={stepData.title} />
+                          <StepperDescriptionWrapper
+                            description={stepData.description}
+                          />
+                        </div>
+                      </Stepper.Item>
+                      <div className="flex gap-4">
+                        {!isLast && (
+                          <div className="flex justify-center ps-[calc(var(--spacing)*4.5-1px)] self-stretch">
+                            <StepperSeparator
+                              status={status}
+                              isLast={isLast}
+                              orientation={orientation}
+                              labelOrientation={labelOrientation}
+                            />
+                          </div>
+                        )}
+                        <div className="my-3 flex-1 ps-4">
+                          <Content
+                            id={
+                              stepData.id as Get.Id<
+                                typeof stepperDefinition.steps
+                              >
+                            }
+                          />
+                        </div>
+                      </div>
+                    </React.Fragment>
+                  );
+                }
 
-								if (isVerticalLabel) {
-									return (
-										<Stepper.Item
-											key={stepData.id}
-											step={stepData.id}
-											className="group peer relative flex w-full flex-col items-center justify-center gap-2"
-										>
-											<StepperTriggerWrapper />
-											<StepperSeparator
-												status={status}
-												isLast={isLast}
-												orientation={orientation}
-												labelOrientation={
-													labelOrientation
-												}
-											/>
-											<div className="flex flex-col items-center text-center gap-1">
-												<StepperTitleWrapper
-													title={stepData.title}
-												/>
-												<StepperDescriptionWrapper
-													description={
-														stepData.description
-													}
-												/>
-											</div>
-										</Stepper.Item>
-									);
-								}
+                if (isVerticalLabel) {
+                  return (
+                    <Stepper.Item
+                      key={stepData.id}
+                      step={stepData.id}
+                      className="group peer relative flex w-full flex-col items-center justify-center gap-2"
+                    >
+                      <StepperTriggerWrapper />
+                      <StepperSeparator
+                        status={status}
+                        isLast={isLast}
+                        orientation={orientation}
+                        labelOrientation={labelOrientation}
+                      />
+                      <div className="flex flex-col items-center text-center gap-1">
+                        <StepperTitleWrapper title={stepData.title} />
+                        <StepperDescriptionWrapper
+                          description={stepData.description}
+                        />
+                      </div>
+                    </Stepper.Item>
+                  );
+                }
 
-								// Horizontal with horizontal labels
-								return (
-									<React.Fragment key={stepData.id}>
-										<Stepper.Item
-											key={stepData.id}
-											step={stepData.id}
-											className="group peer relative flex shrink-0 items-center gap-2"
-										>
-											<StepperTriggerWrapper />
-											<div className="flex flex-col items-start gap-1">
-												<StepperTitleWrapper
-													title={stepData.title}
-												/>
-												<StepperDescriptionWrapper
-													description={
-														stepData.description
-													}
-												/>
-											</div>
-										</Stepper.Item>
-										<StepperSeparator
-											key={`separator-${stepData.id}`}
-											status={status}
-											isLast={isLast}
-											orientation={orientation}
-											labelOrientation={labelOrientation}
-										/>
-									</React.Fragment>
-								);
-							})}
-						</Stepper.List>
+                // Horizontal with horizontal labels
+                return (
+                  <React.Fragment key={stepData.id}>
+                    <Stepper.Item
+                      key={stepData.id}
+                      step={stepData.id}
+                      className="group peer relative flex shrink-0 items-center gap-2"
+                    >
+                      <StepperTriggerWrapper />
+                      <div className="flex flex-col items-start gap-1">
+                        <StepperTitleWrapper title={stepData.title} />
+                        <StepperDescriptionWrapper
+                          description={stepData.description}
+                        />
+                      </div>
+                    </Stepper.Item>
+                    <StepperSeparator
+                      key={`separator-${stepData.id}`}
+                      status={status}
+                      isLast={isLast}
+                      orientation={orientation}
+                      labelOrientation={labelOrientation}
+                    />
+                  </React.Fragment>
+                );
+              })}
+            </Stepper.List>
 
-						{orientation === "horizontal" &&
-							stepper.flow.switch({
-								"step-1": (data) => <Content id={data.id} />,
-								"step-2": (data) => <Content id={data.id} />,
-								"step-3": (data) => <Content id={data.id} />,
-							})}
+            {orientation === "horizontal" &&
+              stepper.flow.switch({
+                "step-1": (data) => <Content id={data.id} />,
+                "step-2": (data) => <Content id={data.id} />,
+                "step-3": (data) => <Content id={data.id} />,
+              })}
 
-						<Stepper.Actions className="flex justify-end gap-4">
-							{!stepper.state.isLast && (
-								<Stepper.Prev
-									render={(domProps) => (
-										<Button
-											type="button"
-											variant="secondary"
-											{...domProps}
-										>
-											Previous
-										</Button>
-									)}
-								/>
-							)}
-							{stepper.state.isLast ? (
-								<Button
-									type="button"
-									onClick={() => stepper.navigation.reset()}
-								>
-									Reset
-								</Button>
-							) : (
-								<Stepper.Next
-									render={(domProps) => (
-										<Button type="button" {...domProps}>
-											Next
-										</Button>
-									)}
-								/>
-							)}
-						</Stepper.Actions>
-					</>
-				)}
-			</Stepper.Root>
-		</div>
-	);
+            <Stepper.Actions className="flex justify-end gap-4">
+              {!stepper.state.isLast && (
+                <Stepper.Prev
+                  render={(domProps) => (
+                    <Button type="button" variant="secondary" {...domProps}>
+                      Previous
+                    </Button>
+                  )}
+                />
+              )}
+              {stepper.state.isLast ? (
+                <Button
+                  type="button"
+                  onClick={() => stepper.navigation.reset()}
+                >
+                  Reset
+                </Button>
+              ) : (
+                <Stepper.Next
+                  render={(domProps) => (
+                    <Button type="button" {...domProps}>
+                      Next
+                    </Button>
+                  )}
+                />
+              )}
+            </Stepper.Actions>
+          </>
+        )}
+      </Stepper.Root>
+    </div>
+  );
 }
 
 const Content = ({ id }: { id: Get.Id<typeof stepperDefinition.steps> }) => {
-	return (
-		<Stepper.Content
-			step={id}
-			render={(props) => (
-				<div
-					{...props}
-					className="h-[150px] content-center rounded border bg-secondary text-secondary-foreground p-8"
-				>
-					<p className="text-xl font-normal">Content for {id}</p>
-				</div>
-			)}
-		/>
-	);
+  return (
+    <Stepper.Content
+      step={id}
+      render={(props) => (
+        <div
+          {...props}
+          className="h-[150px] content-center rounded border bg-secondary text-secondary-foreground p-8"
+        >
+          <p className="text-xl font-normal">Content for {id}</p>
+        </div>
+      )}
+    />
+  );
 };

--- a/apps/docs/registry/radix-ui/ui/button.tsx
+++ b/apps/docs/registry/radix-ui/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
@@ -10,20 +10,27 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
-        destructive: "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        destructive:
+          "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         icon: "size-8",
-        "icon-xs": "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
         "icon-lg": "size-9",
       },
     },
@@ -31,8 +38,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -42,9 +49,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : "button";
 
   return (
     <Comp
@@ -54,7 +61,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/apps/docs/registry/radix-ui/ui/input.tsx
+++ b/apps/docs/registry/radix-ui/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -9,11 +9,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/apps/docs/registry/radix-ui/ui/label.tsx
+++ b/apps/docs/registry/radix-ui/ui/label.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import { Label as LabelPrimitive } from "radix-ui";
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({
   className,
@@ -14,11 +14,11 @@ function Label({
       data-slot="label"
       className={cn(
         "gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/apps/docs/registry/radix-ui/ui/radio-group.tsx
+++ b/apps/docs/registry/radix-ui/ui/radio-group.tsx
@@ -1,10 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
-
-import { cn } from "@/lib/utils"
-import { CircleIcon } from "lucide-react"
+import { CircleIcon } from "lucide-react";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import type React from "react";
+import { cn } from "@/lib/utils";
 
 function RadioGroup({
   className,
@@ -16,7 +15,7 @@ function RadioGroup({
       className={cn("grid gap-2 w-full", className)}
       {...props}
     />
-  )
+  );
 }
 
 function RadioGroupItem({
@@ -28,7 +27,7 @@ function RadioGroupItem({
       data-slot="radio-group-item"
       className={cn(
         "border-input text-primary dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-[3px] aria-invalid:ring-[3px] group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     >
@@ -39,7 +38,7 @@ function RadioGroupItem({
         <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
-  )
+  );
 }
 
-export { RadioGroup, RadioGroupItem }
+export { RadioGroup, RadioGroupItem };

--- a/apps/docs/registry/radix-ui/ui/separator.tsx
+++ b/apps/docs/registry/radix-ui/ui/separator.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import type React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Separator({
   className,
@@ -18,11 +18,11 @@ function Separator({
       orientation={orientation}
       className={cn(
         "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/biome.json
+++ b/biome.json
@@ -1,40 +1,56 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
-	"files": {
-		"includes": ["**", "!.turbo", "!.next", "!.changeset", "!.pnpm-store", "!packages/react/dist"]
-	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"formatter": {
-		"lineWidth": 120
-	},
-	"css": {
-		"parser": {
-			"tailwindDirectives": true
-		}
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"a11y": {
-				"useKeyWithClickEvents": "off"
-			},
-			"nursery": {
-				"useSortedClasses": "off"
-			},
-			"style": {
-				"useBlockStatements": "off"
-			},
-			"suspicious": {
-				"noExplicitAny": "off",
-				"noArrayIndexKey": "off",
-				"noConsole": { "level": "error", "options": { "allow": ["log"] } }
-			},
-			"correctness": {
-				"noUnusedVariables": "error",
-				"noUnusedImports": "error",
-				"useExhaustiveDependencies": "off"
-			}
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/2.4.2/schema.json",
+  "files": {
+    "includes": [
+      "**",
+      "!.turbo",
+      "!.next",
+      "!.changeset",
+      "!.pnpm-store",
+      "!packages/react/dist"
+    ]
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "formatter": {
+    "lineWidth": 120
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": {
+        "useKeyWithClickEvents": "off"
+      },
+      "nursery": {
+        "useSortedClasses": "off"
+      },
+      "style": {
+        "useBlockStatements": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noArrayIndexKey": "off",
+        "noConsole": { "level": "error", "options": { "allow": ["log"] } }
+      },
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error",
+        "useExhaustiveDependencies": "off"
+      },
+      "complexity": {
+        "noBannedTypes": "error"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-	"name": "stepperize",
-	"private": true,
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/damianricobelli/stepperize.git"
-	},
-	"scripts": {
-		"build": "turbo build",
-		"dev": "turbo dev",
-		"lint": "turbo lint",
-		"clean": "turbo run clean && rm -rf node_modules .pnpm-store .turbo",
-		"format-and-lint": "biome check .",
-		"format-and-lint:fix": "biome check . --write",
-		"ci:version": "changeset version",
-		"ci:release": "changeset publish"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "2.3.13",
-		"@changesets/changelog-github": "0.5.2",
-		"@changesets/cli": "^2.29.8",
-		"turbo": "2.8.0",
-		"typescript": "catalog:"
-	},
-	"packageManager": "pnpm@10.28.0",
-	"engines": {
-		"node": ">=18"
-	}
+  "name": "stepperize",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/damianricobelli/stepperize.git"
+  },
+  "scripts": {
+    "build": "turbo build",
+    "dev": "turbo dev",
+    "lint": "turbo lint",
+    "clean": "turbo run clean && rm -rf node_modules .pnpm-store .turbo",
+    "format-and-lint": "biome check .",
+    "format-and-lint:fix": "biome check . --write",
+    "ci:version": "changeset version",
+    "ci:release": "changeset publish"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.2",
+    "@changesets/changelog-github": "0.5.2",
+    "@changesets/cli": "^2.29.8",
+    "turbo": "2.8.10",
+    "typescript": "catalog:"
+  },
+  "packageManager": "pnpm@10.28.0",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/packages/core/src/tests/utils.test.ts
+++ b/packages/core/src/tests/utils.test.ts
@@ -1,181 +1,181 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-	generateCommonStepperUseFns,
-	generateStepperUtils,
-	getInitialMetadata,
-	getInitialStepIndex,
-	updateStepIndex,
+  generateCommonStepperUseFns,
+  generateStepperUtils,
+  getInitialMetadata,
+  getInitialStepIndex,
+  updateStepIndex,
 } from "../utils";
 
 const steps = [
-	{ id: "first", label: "Step 1" },
-	{ id: "second", label: "Step 2" },
-	{ id: "third", label: "Step 3" },
+  { id: "first", label: "Step 1" },
+  { id: "second", label: "Step 2" },
+  { id: "third", label: "Step 3" },
 ];
 
 describe("generateStepperUtils", () => {
-	const utils = generateStepperUtils(...steps);
+  const utils = generateStepperUtils(...steps);
 
-	it("returns all steps", () => {
-		expect(utils.getAll()).toEqual(steps);
-	});
+  it("returns all steps", () => {
+    expect(utils.getAll()).toEqual(steps);
+  });
 
-	it("get returns a step by id", () => {
-		expect(utils.get("second")).toEqual({ id: "second", label: "Step 2" });
-	});
+  it("get returns a step by id", () => {
+    expect(utils.get("second")).toEqual({ id: "second", label: "Step 2" });
+  });
 
-	it("get returns undefined for nonexistent id", () => {
-		expect(utils.get("nonexistent" as any)).toBeUndefined();
-	});
+  it("get returns undefined for nonexistent id", () => {
+    expect(utils.get("nonexistent" as any)).toBeUndefined();
+  });
 
-	it("getIndex returns index by id", () => {
-		expect(utils.getIndex("third")).toBe(2);
-	});
+  it("getIndex returns index by id", () => {
+    expect(utils.getIndex("third")).toBe(2);
+  });
 
-	it("getByIndex returns step by index", () => {
-		expect(utils.getByIndex(0)).toEqual(steps[0]);
-	});
+  it("getByIndex returns step by index", () => {
+    expect(utils.getByIndex(0)).toEqual(steps[0]);
+  });
 
-	it("getFirst and getLast return extremes", () => {
-		expect(utils.getFirst()).toEqual(steps[0]);
-		expect(utils.getLast()).toEqual(steps[2]);
-	});
+  it("getFirst and getLast return extremes", () => {
+    expect(utils.getFirst()).toEqual(steps[0]);
+    expect(utils.getLast()).toEqual(steps[2]);
+  });
 
-	it("getNext and getPrev return neighbors", () => {
-		expect(utils.getNext("first")).toEqual(steps[1]);
-		expect(utils.getPrev("third")).toEqual(steps[1]);
-	});
+  it("getNext and getPrev return neighbors", () => {
+    expect(utils.getNext("first")).toEqual(steps[1]);
+    expect(utils.getPrev("third")).toEqual(steps[1]);
+  });
 
-	it("getNeighbors returns prev and next correctly", () => {
-		expect(utils.getNeighbors("second")).toEqual({
-			prev: steps[0],
-			next: steps[2],
-		});
-		expect(utils.getNeighbors("first")).toEqual({ prev: null, next: steps[1] });
-		expect(utils.getNeighbors("third")).toEqual({ prev: steps[1], next: null });
-	});
+  it("getNeighbors returns prev and next correctly", () => {
+    expect(utils.getNeighbors("second")).toEqual({
+      prev: steps[0],
+      next: steps[2],
+    });
+    expect(utils.getNeighbors("first")).toEqual({ prev: null, next: steps[1] });
+    expect(utils.getNeighbors("third")).toEqual({ prev: steps[1], next: null });
+  });
 
-	it("getNext returns undefined for last step", () => {
-		expect(utils.getNext("third")).toBeUndefined();
-	});
+  it("getNext returns undefined for last step", () => {
+    expect(utils.getNext("third")).toBeUndefined();
+  });
 
-	it("getPrev returns undefined for first step", () => {
-		expect(utils.getPrev("first")).toBeUndefined();
-	});
+  it("getPrev returns undefined for first step", () => {
+    expect(utils.getPrev("first")).toBeUndefined();
+  });
 });
 
 describe("getInitialStepIndex", () => {
-	it("returns 0 if no initialStep is passed", () => {
-		expect(getInitialStepIndex(steps)).toBe(0);
-	});
+  it("returns 0 if no initialStep is passed", () => {
+    expect(getInitialStepIndex(steps)).toBe(0);
+  });
 
-	it("returns correct index if the step exists", () => {
-		expect(getInitialStepIndex(steps, "second")).toBe(1);
-	});
+  it("returns correct index if the step exists", () => {
+    expect(getInitialStepIndex(steps, "second")).toBe(1);
+  });
 
-	it("returns 0 if the step does not exist", () => {
-		expect(getInitialStepIndex(steps, "not-exist" as any)).toBe(0);
-	});
+  it("returns 0 if the step does not exist", () => {
+    expect(getInitialStepIndex(steps, "not-exist" as any)).toBe(0);
+  });
 });
 
 describe("getInitialMetadata", () => {
-	it("returns null by default for each step", () => {
-		const metadata = getInitialMetadata(steps);
-		expect(metadata).toEqual({ first: null, second: null, third: null });
-	});
+  it("returns null by default for each step", () => {
+    const metadata = getInitialMetadata(steps);
+    expect(metadata).toEqual({ first: null, second: null, third: null });
+  });
 
-	it("applies initial metadata if passed", () => {
-		const metadata = getInitialMetadata(steps, { first: { foo: "bar" } });
-		expect(metadata.first).toEqual({ foo: "bar" });
-		expect(metadata.second).toBeNull();
-	});
+  it("applies initial metadata if passed", () => {
+    const metadata = getInitialMetadata(steps, { first: { foo: "bar" } });
+    expect(metadata.first).toEqual({ foo: "bar" });
+    expect(metadata.second).toBeNull();
+  });
 });
 
 describe("generateCommonStepperUseFns", () => {
-	const fns = generateCommonStepperUseFns(steps, steps[1], 1);
+  const fns = generateCommonStepperUseFns(steps, steps[1], 1);
 
-	it("switch executes function of the current step", () => {
-		const result = fns.switch({
-			second: (s) => `Hola ${s.label}`,
-		});
-		expect(result).toBe("Hola Step 2");
-	});
+  it("switch executes function of the current step", () => {
+    const result = fns.switch({
+      second: (s) => `Hola ${s.label}`,
+    });
+    expect(result).toBe("Hola Step 2");
+  });
 
-	it("when executes whenFn if id matches", () => {
-		const result = fns.when(
-			"second",
-			(s: (typeof steps)[0]) => s.label,
-			() => "nope",
-		);
-		expect(result).toBe("Step 2");
-	});
+  it("when executes whenFn if id matches", () => {
+    const result = fns.when(
+      "second",
+      (s: (typeof steps)[0]) => s.label,
+      () => "nope",
+    );
+    expect(result).toBe("Step 2");
+  });
 
-	it("when executes elseFn if id does not match", () => {
-		const result = fns.when(
-			"first",
-			() => "ok",
-			() => "fallback",
-		);
-		expect(result).toBe("fallback");
-	});
+  it("when executes elseFn if id does not match", () => {
+    const result = fns.when(
+      "first",
+      () => "ok",
+      () => "fallback",
+    );
+    expect(result).toBe("fallback");
+  });
 
-	it("when with array id executes whenFn only when id and all conditions match", () => {
-		const resultMatch = fns.when(
-			["second", true, true],
-			(s: (typeof steps)[0]) => s.label,
-			() => "nope",
-		);
-		expect(resultMatch).toBe("Step 2");
-		const resultNoMatchId = fns.when(
-			["first", true, true],
-			() => "ok",
-			() => "fallback",
-		);
-		expect(resultNoMatchId).toBe("fallback");
-		const resultNoMatchCond = fns.when(
-			["second", false, true],
-			() => "ok",
-			() => "fallback",
-		);
-		expect(resultNoMatchCond).toBe("fallback");
-	});
+  it("when with array id executes whenFn only when id and all conditions match", () => {
+    const resultMatch = fns.when(
+      ["second", true, true],
+      (s: (typeof steps)[0]) => s.label,
+      () => "nope",
+    );
+    expect(resultMatch).toBe("Step 2");
+    const resultNoMatchId = fns.when(
+      ["first", true, true],
+      () => "ok",
+      () => "fallback",
+    );
+    expect(resultNoMatchId).toBe("fallback");
+    const resultNoMatchCond = fns.when(
+      ["second", false, true],
+      () => "ok",
+      () => "fallback",
+    );
+    expect(resultNoMatchCond).toBe("fallback");
+  });
 
-	it("match executes function associated with the state", () => {
-		const result = fns.match("second", {
-			second: (s) => s.label,
-		});
-		expect(result).toBe("Step 2");
-	});
+  it("match executes function associated with the state", () => {
+    const result = fns.match("second", {
+      second: (s) => s.label,
+    });
+    expect(result).toBe("Step 2");
+  });
 
-	it("match returns null if there is no step", () => {
-		const result = fns.match("unknown" as any, {});
-		expect(result).toBeNull();
-	});
+  it("match returns null if there is no step", () => {
+    const result = fns.match("unknown" as any, {});
+    expect(result).toBeNull();
+  });
 
-	it("is returns true when current step id matches", () => {
-		expect(fns.is("second")).toBe(true);
-	});
+  it("is returns true when current step id matches", () => {
+    expect(fns.is("second")).toBe(true);
+  });
 
-	it("is returns false when current step id does not match", () => {
-		expect(fns.is("first")).toBe(false);
-		expect(fns.is("third")).toBe(false);
-	});
+  it("is returns false when current step id does not match", () => {
+    expect(fns.is("first")).toBe(false);
+    expect(fns.is("third")).toBe(false);
+  });
 });
 
 describe("updateStepIndex", () => {
-	it("sets valid index", () => {
-		const setter = vi.fn();
-		updateStepIndex(steps, 1, setter);
-		expect(setter).toHaveBeenCalledWith(1);
-	});
+  it("sets valid index", () => {
+    const setter = vi.fn();
+    updateStepIndex(steps, 1, setter);
+    expect(setter).toHaveBeenCalledWith(1);
+  });
 
-	it("throws error if newIndex < 0", () => {
-		const setter = vi.fn();
-		expect(() => updateStepIndex(steps, -1, setter)).toThrowError(/first step/);
-	});
+  it("throws error if newIndex < 0", () => {
+    const setter = vi.fn();
+    expect(() => updateStepIndex(steps, -1, setter)).toThrowError(/first step/);
+  });
 
-	it("throws error if newIndex >= steps.length", () => {
-		const setter = vi.fn();
-		expect(() => updateStepIndex(steps, 10, setter)).toThrowError(/last step/);
-	});
+  it("throws error if newIndex >= steps.length", () => {
+    const setter = vi.fn();
+    expect(() => updateStepIndex(steps, 10, setter)).toThrowError(/last step/);
+  });
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
-type Step<Id extends string = string, Data extends object = {}> = {
-	id: Id;
+type Step<Id extends string = string, Data extends object = object> = {
+  id: Id;
 } & Data;
 type Metadata = Record<string, any> | null;
 
@@ -7,244 +7,256 @@ type Metadata = Record<string, any> | null;
 type StepStatus = "active" | "inactive" | "success";
 
 type StepperState<Steps extends Step[] = Step[]> = {
-	/**
-	 * The steps of the stepper.
-	 * @returns The steps of the stepper.
-	 */
-	all: Steps;
-	/**
-	 * The current step of the stepper.
-	 * @returns The current step of the stepper.
-	 */
-	current: {
-		data: Steps[number];
-		index: number;
-		status: StepStatus;
-		metadata: {
-			get: <M extends Metadata>() => M;
-			set: <M extends Metadata>(values: M) => void;
-			reset: (keepInitialMetadata?: boolean) => void;
-		}
-	}
-	/**
-	 * Returns true if the current step is the last step.
-	 * @returns True if the current step is the last step.
-	 */
-	isLast: boolean;
-	/**
-	 * Returns true if the current step is the first step.
-	 * @returns True if the current step is the first step.
-	 */
-	isFirst: boolean;
-	/**
-	 * Returns true if the stepper is transitioning.
-	 * @returns True if the stepper is transitioning.
-	 */
-	isTransitioning: boolean;
+  /**
+   * The steps of the stepper.
+   * @returns The steps of the stepper.
+   */
+  all: Steps;
+  /**
+   * The current step of the stepper.
+   * @returns The current step of the stepper.
+   */
+  current: {
+    data: Steps[number];
+    index: number;
+    status: StepStatus;
+    metadata: {
+      get: <M extends Metadata>() => M;
+      set: <M extends Metadata>(values: M) => void;
+      reset: (keepInitialMetadata?: boolean) => void;
+    };
+  };
+  /**
+   * Returns true if the current step is the last step.
+   * @returns True if the current step is the last step.
+   */
+  isLast: boolean;
+  /**
+   * Returns true if the current step is the first step.
+   * @returns True if the current step is the first step.
+   */
+  isFirst: boolean;
+  /**
+   * Returns true if the stepper is transitioning.
+   * @returns True if the stepper is transitioning.
+   */
+  isTransitioning: boolean;
 };
 
 /** Optional payload for navigation (e.g. metadata to merge into transition context without waiting for setState). */
 type TransitionPayload<Steps extends Step[] = Step[]> = {
-	/** Metadata to merge into ctx.metadata for this transition and persist. */
-	metadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+  /** Metadata to merge into ctx.metadata for this transition and persist. */
+  metadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
 };
 
 type StepperNavigation<Steps extends Step[] = Step[]> = {
-	/**
-	 * Advances to the next step.
-	 * @param payload - Optional metadata to merge into transition context (avoids stale metadata in onBeforeTransition).
-	 * @returns void or Promise when lifecycle hooks run.
-	 */
-	next: (payload?: TransitionPayload<Steps>) => void | Promise<void>;
-	/**
-	 * Returns to the previous step.
-	 * @param payload - Optional metadata to merge into transition context.
-	 * @returns void or Promise when lifecycle hooks run.
-	 */
-	prev: (payload?: TransitionPayload<Steps>) => void | Promise<void>;
-	/**
-	 * Navigates to a specific step by its ID.
-	 * @param id - The ID of the step to navigate to.
-	 * @param payload - Optional metadata to merge into transition context.
-	 * @returns void or Promise when lifecycle hooks run.
-	 */
-	goTo: (id: Get.Id<Steps>, payload?: TransitionPayload<Steps>) => void | Promise<void>;
-	/**
-	 * Resets the stepper to its initial state.
-	 * @returns The initial state of the stepper.
-	 */
-	reset: () => void;
+  /**
+   * Advances to the next step.
+   * @param payload - Optional metadata to merge into transition context (avoids stale metadata in onBeforeTransition).
+   * @returns void or Promise when lifecycle hooks run.
+   */
+  next: (payload?: TransitionPayload<Steps>) => void | Promise<void>;
+  /**
+   * Returns to the previous step.
+   * @param payload - Optional metadata to merge into transition context.
+   * @returns void or Promise when lifecycle hooks run.
+   */
+  prev: (payload?: TransitionPayload<Steps>) => void | Promise<void>;
+  /**
+   * Navigates to a specific step by its ID.
+   * @param id - The ID of the step to navigate to.
+   * @param payload - Optional metadata to merge into transition context.
+   * @returns void or Promise when lifecycle hooks run.
+   */
+  goTo: (
+    id: Get.Id<Steps>,
+    payload?: TransitionPayload<Steps>,
+  ) => void | Promise<void>;
+  /**
+   * Resets the stepper to its initial state.
+   * @returns The initial state of the stepper.
+   */
+  reset: () => void;
 };
 
 type StepperLookup<Steps extends Step[] = Step[]> = {
-	/**
-	 * Retrieves all steps.
-	 * @returns An array of all steps.
-	 */
-	getAll: () => Steps;
-	/**
-	 * Retrieves a step by its ID.
-	 * @param id - The ID of the step to retrieve.
-	 * @returns The step with the specified ID.
-	 */
-	get: <Id extends Get.Id<Steps>>(id: Id) => Get.StepById<Steps, Id>;
-	/**
-	 * Retrieves the index of a step by its ID.
-	 * @param id - The ID of the step to retrieve the index for.
-	 * @returns The index of the step.
-	 */
-	getIndex: <Id extends Get.Id<Steps>>(id: Id) => number;
-	/**
-	 * Retrieves a step by its index.
-	 * @param index - The index of the step to retrieve.
-	 * @returns The step at the specified index.
-	 */
-	getByIndex: <Index extends number>(index: Index) => Steps[Index];
-	/**
-	 * Retrieves the first step.
-	 * @returns The first step.
-	 */
-	getFirst: () => Steps[number];
-	/**
-	 * Retrieves the last step.
-	 * @returns The last step.
-	 */
-	getLast: () => Steps[number];
-	/**
-	 * Retrieves the next step after the specified ID.
-	 * @param id - The ID of the current step.
-	 * @returns The next step.
-	 */
-	getNext: <Id extends Get.Id<Steps>>(id: Id) => Steps[number];
-	/**
-	 * Retrieves the previous step before the specified ID.
-	 * @param id - The ID of the current step.
-	 * @returns The previous step.
-	 */
-	getPrev: <Id extends Get.Id<Steps>>(id: Id) => Steps[number];
-	/**
-	 * Retrieves the neighboring steps (previous and next) of the specified step.
-	 * @param id - The ID of the current step.
-	 * @returns An object containing the previous and next steps.
-	 */
-	getNeighbors: <Id extends Get.Id<Steps>>(id: Id) => { prev: Steps[number] | null; next: Steps[number] | null };
+  /**
+   * Retrieves all steps.
+   * @returns An array of all steps.
+   */
+  getAll: () => Steps;
+  /**
+   * Retrieves a step by its ID.
+   * @param id - The ID of the step to retrieve.
+   * @returns The step with the specified ID.
+   */
+  get: <Id extends Get.Id<Steps>>(id: Id) => Get.StepById<Steps, Id>;
+  /**
+   * Retrieves the index of a step by its ID.
+   * @param id - The ID of the step to retrieve the index for.
+   * @returns The index of the step.
+   */
+  getIndex: <Id extends Get.Id<Steps>>(id: Id) => number;
+  /**
+   * Retrieves a step by its index.
+   * @param index - The index of the step to retrieve.
+   * @returns The step at the specified index.
+   */
+  getByIndex: <Index extends number>(index: Index) => Steps[Index];
+  /**
+   * Retrieves the first step.
+   * @returns The first step.
+   */
+  getFirst: () => Steps[number];
+  /**
+   * Retrieves the last step.
+   * @returns The last step.
+   */
+  getLast: () => Steps[number];
+  /**
+   * Retrieves the next step after the specified ID.
+   * @param id - The ID of the current step.
+   * @returns The next step.
+   */
+  getNext: <Id extends Get.Id<Steps>>(id: Id) => Steps[number];
+  /**
+   * Retrieves the previous step before the specified ID.
+   * @param id - The ID of the current step.
+   * @returns The previous step.
+   */
+  getPrev: <Id extends Get.Id<Steps>>(id: Id) => Steps[number];
+  /**
+   * Retrieves the neighboring steps (previous and next) of the specified step.
+   * @param id - The ID of the current step.
+   * @returns An object containing the previous and next steps.
+   */
+  getNeighbors: <Id extends Get.Id<Steps>>(
+    id: Id,
+  ) => { prev: Steps[number] | null; next: Steps[number] | null };
 };
 
 type StepperFlow<Steps extends Step[] = Step[]> = {
-	/**
-	 * Executes a function based on the current step ID.
-	 * @param id - The ID of the step to check.
-	 * @param whenFn - Function to execute if the current step matches the ID.
-	 * @param elseFn - Optional function to execute if the current step does not match the ID.
-	 * @returns The result of whenFn or elseFn.
-	 */
-	when: <Id extends Get.Id<Steps>, R1, R2>(
-		id: Id | [Id, ...boolean[]],
-		whenFn: (step: Get.StepById<Steps, Id>) => R1,
-		elseFn?: (step: Get.StepSansId<Steps, Id>) => R2,
-	) => R1 | R2;
-	/**
-	 * Executes a function based on a switch-case-like structure for steps.
-	 * @param when - An object mapping step IDs to functions.
-	 * @returns The result of the function corresponding to the current step ID.
-	 */
-	switch: <R>(when: Get.Switch<Steps, R>) => R;
-	/**
-	 * Matches the current state with a set of possible states and executes the corresponding function.
-	 * @param state - The current state ID.
-	 * @param matches - An object mapping state IDs to functions.
-	 * @returns The result of the matched function or null if no match is found.
-	 */
-	match: <State extends Get.Id<Steps>, R>(state: State, matches: Get.Switch<Steps, R>) => R | null;
-	/**
-	 * Returns whether the current step has the given ID. Use for conditionals (e.g. `stepper.flow.is("payment")`).
-	 *
-	 * @param id - Step ID to check (e.g. `"shipping"`, `"payment"`).
-	 * @returns `true` if the current step's id equals `id`, otherwise `false`.
-	 *
-	 * @example
-	 * ```ts
-	 * if (stepper.flow.is("payment")) {
-	 *   return <PaymentForm />;
-	 * }
-	 * // or in JSX
-	 * {stepper.flow.is("confirmation") && <Summary />}
-	 * ```
-	 */
-	is: <Id extends Get.Id<Steps>>(id: Id) => boolean;
+  /**
+   * Executes a function based on the current step ID.
+   * @param id - The ID of the step to check.
+   * @param whenFn - Function to execute if the current step matches the ID.
+   * @param elseFn - Optional function to execute if the current step does not match the ID.
+   * @returns The result of whenFn or elseFn.
+   */
+  when: <Id extends Get.Id<Steps>, R1, R2>(
+    id: Id | [Id, ...boolean[]],
+    whenFn: (step: Get.StepById<Steps, Id>) => R1,
+    elseFn?: (step: Get.StepSansId<Steps, Id>) => R2,
+  ) => R1 | R2;
+  /**
+   * Executes a function based on a switch-case-like structure for steps.
+   * @param when - An object mapping step IDs to functions.
+   * @returns The result of the function corresponding to the current step ID.
+   */
+  switch: <R>(when: Get.Switch<Steps, R>) => R;
+  /**
+   * Matches the current state with a set of possible states and executes the corresponding function.
+   * @param state - The current state ID.
+   * @param matches - An object mapping state IDs to functions.
+   * @returns The result of the matched function or null if no match is found.
+   */
+  match: <State extends Get.Id<Steps>, R>(
+    state: State,
+    matches: Get.Switch<Steps, R>,
+  ) => R | null;
+  /**
+   * Returns whether the current step has the given ID. Use for conditionals (e.g. `stepper.flow.is("payment")`).
+   *
+   * @param id - Step ID to check (e.g. `"shipping"`, `"payment"`).
+   * @returns `true` if the current step's id equals `id`, otherwise `false`.
+   *
+   * @example
+   * ```ts
+   * if (stepper.flow.is("payment")) {
+   *   return <PaymentForm />;
+   * }
+   * // or in JSX
+   * {stepper.flow.is("confirmation") && <Summary />}
+   * ```
+   */
+  is: <Id extends Get.Id<Steps>>(id: Id) => boolean;
 };
 
 type StepperMetadata<Steps extends Step[] = Step[]> = {
-	/**
-	 * The metadata values for each step.
-	 * @returns The metadata values for each step.
-	 */
-	values: Record<Get.Id<Steps>, Metadata>;
-	/**
-	 * Sets the metadata values for a step.
-	 * @param id - The ID of the step to set the metadata values for.
-	 * @param values - The values to set for the metadata.
-	 */
-	set: <M extends Metadata>(id: Get.Id<Steps>, values: M) => void;
-	/**
-	 * Gets the metadata values for a step.
-	 * @param id - The ID of the step to get the metadata values for.
-	 * @returns The metadata values for the step.
-	 */
-	get: <M extends Metadata>(id: Get.Id<Steps>) => M;
-	/**
-	 * Resets the metadata values to the initial state.
-	 * @param keepInitialMetadata - If true, the initial metadata values defined in the useStepper hook will be kept.
-	 */
-	reset: (keepInitialMetadata?: boolean) => void;
+  /**
+   * The metadata values for each step.
+   * @returns The metadata values for each step.
+   */
+  values: Record<Get.Id<Steps>, Metadata>;
+  /**
+   * Sets the metadata values for a step.
+   * @param id - The ID of the step to set the metadata values for.
+   * @param values - The values to set for the metadata.
+   */
+  set: <M extends Metadata>(id: Get.Id<Steps>, values: M) => void;
+  /**
+   * Gets the metadata values for a step.
+   * @param id - The ID of the step to get the metadata values for.
+   * @returns The metadata values for the step.
+   */
+  get: <M extends Metadata>(id: Get.Id<Steps>) => M;
+  /**
+   * Resets the metadata values to the initial state.
+   * @param keepInitialMetadata - If true, the initial metadata values defined in the useStepper hook will be kept.
+   */
+  reset: (keepInitialMetadata?: boolean) => void;
 };
 
+type MaybePromise<T> = T | Promise<T>;
+
 type StepperLifecycle<Steps extends Step[] = Step[]> = {
-	/**
-	 * Registers a callback before each transition. Multiple callbacks are supported; returns unsubscribe.
-	 * @param cb - The callback (return false or Promise<false> to cancel transition).
-	 * @returns Unsubscribe function.
-	 */
-	onBeforeTransition: (
-		cb: (ctx: TransitionContext<Steps>) => void | Promise<void | false>,
-	) => () => void;
-	/**
-	 * Registers a callback after each transition. Multiple callbacks are supported; returns unsubscribe.
-	 * @param cb - The callback.
-	 * @returns Unsubscribe function.
-	 */
-	onAfterTransition: (cb: (ctx: TransitionContext<Steps>) => void | Promise<void>) => () => void;
+  /**
+   * Registers a callback before each transition. Multiple callbacks are supported; returns unsubscribe.
+   * @param cb - The callback (return false or Promise<false> to cancel transition).
+   * @returns Unsubscribe function.
+   */
+  onBeforeTransition: (
+    cb: (ctx: TransitionContext<Steps>) => MaybePromise<void | false>,
+  ) => () => void;
+  /**
+   * Registers a callback after each transition. Multiple callbacks are supported; returns unsubscribe.
+   * @param cb - The callback.
+   * @returns Unsubscribe function.
+   */
+  onAfterTransition: (
+    cb: (ctx: TransitionContext<Steps>) => MaybePromise<void>,
+  ) => () => void;
 };
 
 type TransitionContext<Steps extends Step[] = Step[]> = {
-	/**
-	 * The step being transitioned from.
-	 */
-	from: Steps[number];
-	/**
-	 * The step being transitioned to.
-	 */
-	to: Steps[number];
-	/**
-	 * The metadata for the transition.
-	 */
-	metadata: Record<Get.Id<Steps>, Metadata>;
-	/**
-	 * The statuses for the transition.
-	 */
-	statuses: Record<Get.Id<Steps>, StepStatus>;
-	/**
-	 * The direction of the transition.
-	 */
-	direction: "next" | "prev" | "goTo";
-	/**
-	 * The index of the step being transitioned from.
-	 */
-	fromIndex: number;
-	/**
-	 * The index of the step being transitioned to.
-	 */
-	toIndex: number;
+  /**
+   * The step being transitioned from.
+   */
+  from: Steps[number];
+  /**
+   * The step being transitioned to.
+   */
+  to: Steps[number];
+  /**
+   * The metadata for the transition.
+   */
+  metadata: Record<Get.Id<Steps>, Metadata>;
+  /**
+   * The statuses for the transition.
+   */
+  statuses: Record<Get.Id<Steps>, StepStatus>;
+  /**
+   * The direction of the transition.
+   */
+  direction: "next" | "prev" | "goTo";
+  /**
+   * The index of the step being transitioned from.
+   */
+  fromIndex: number;
+  /**
+   * The index of the step being transitioned to.
+   */
+  toIndex: number;
 };
 
 /**
@@ -261,67 +273,73 @@ type TransitionContext<Steps extends Step[] = Step[]> = {
  * ```
  */
 type Stepper<Steps extends Step[] = Step[]> = {
-	/**
-	 * Read-only state: current step data, index, status (active/inactive/success), and metadata get/set for the active step.
-	 * @example `stepper.state.current.data` — current step; `stepper.state.current.metadata.get()` — current step metadata
-	 */
-	state: StepperState<Steps>;
-	/**
-	 * Imperative navigation: `next()`, `prev()`, `goTo(id)`, `reset()`.
-	 * @example `stepper.navigation.next()` — advance; `stepper.navigation.goTo("confirm")` — jump to step by id
-	 */
-	navigation: StepperNavigation<Steps>;
-	/**
-	 * Step lookup: `getAll()`, `get(id)`, `getIndex(id)`, `getByIndex(i)`, `getFirst` / `getLast` / `getNext` / `getPrev` / `getNeighbors(id)`.
-	 * @example `stepper.lookup.get("summary")` — get step by id; `stepper.lookup.getNext(stepper.state.current.data.id)` — next step
-	 */
-	lookup: StepperLookup<Steps>;
-	/**
-	 * Branch by step id: `when(id, whenFn, elseFn?)`, `switch(when)`, `match(state, matches)`.
-	 * @example `stepper.flow.when("payment", () => <Payment />)` — render by step; `stepper.flow.switch({ payment: () => 1, done: () => 2 })` — switch by id
-	 */
-	flow: StepperFlow<Steps>;
-	/**
-	 * Step-scoped metadata: `values`, `set(id, values)`, `get(id)`, `reset()`.
-	 * @example `stepper.metadata.set("form", { draft: true })` — persist data per step; `stepper.metadata.get("form")` — read it
-	 */
-	metadata: StepperMetadata<Steps>;
-	/**
-	 * Lifecycle hooks: `onBeforeTransition()`, `onAfterTransition()`.
-	 * @example `stepper.lifecycle.onBeforeTransition(() => { console.log("before transition") });` — before transition; `stepper.lifecycle.onAfterTransition(() => { console.log("after transition") });` — after transition
-	 */
-	lifecycle: StepperLifecycle<Steps>;
-}
+  /**
+   * Read-only state: current step data, index, status (active/inactive/success), and metadata get/set for the active step.
+   * @example `stepper.state.current.data` — current step; `stepper.state.current.metadata.get()` — current step metadata
+   */
+  state: StepperState<Steps>;
+  /**
+   * Imperative navigation: `next()`, `prev()`, `goTo(id)`, `reset()`.
+   * @example `stepper.navigation.next()` — advance; `stepper.navigation.goTo("confirm")` — jump to step by id
+   */
+  navigation: StepperNavigation<Steps>;
+  /**
+   * Step lookup: `getAll()`, `get(id)`, `getIndex(id)`, `getByIndex(i)`, `getFirst` / `getLast` / `getNext` / `getPrev` / `getNeighbors(id)`.
+   * @example `stepper.lookup.get("summary")` — get step by id; `stepper.lookup.getNext(stepper.state.current.data.id)` — next step
+   */
+  lookup: StepperLookup<Steps>;
+  /**
+   * Branch by step id: `when(id, whenFn, elseFn?)`, `switch(when)`, `match(state, matches)`.
+   * @example `stepper.flow.when("payment", () => <Payment />)` — render by step; `stepper.flow.switch({ payment: () => 1, done: () => 2 })` — switch by id
+   */
+  flow: StepperFlow<Steps>;
+  /**
+   * Step-scoped metadata: `values`, `set(id, values)`, `get(id)`, `reset()`.
+   * @example `stepper.metadata.set("form", { draft: true })` — persist data per step; `stepper.metadata.get("form")` — read it
+   */
+  metadata: StepperMetadata<Steps>;
+  /**
+   * Lifecycle hooks: `onBeforeTransition()`, `onAfterTransition()`.
+   * @example `stepper.lifecycle.onBeforeTransition(() => { console.log("before transition") });` — before transition; `stepper.lifecycle.onAfterTransition(() => { console.log("after transition") });` — after transition
+   */
+  lifecycle: StepperLifecycle<Steps>;
+};
 
 namespace Get {
-	/** Returns a union of possible IDs from the given Steps. */
-	export type Id<Steps extends Step[] = Step[]> = Steps[number]["id"];
+  /** Returns a union of possible IDs from the given Steps. */
+  export type Id<Steps extends Step[] = Step[]> = Steps[number]["id"];
 
-	/** Returns a Step from the given Steps with the given Step Id. */
-	export type StepById<Steps extends Step[], Id extends Get.Id<Steps>> = Extract<Steps[number], { id: Id }>;
+  /** Returns a Step from the given Steps with the given Step Id. */
+  export type StepById<
+    Steps extends Step[],
+    Id extends Get.Id<Steps>,
+  > = Extract<Steps[number], { id: Id }>;
 
-	/** Returns any Steps from the given Steps without the given Step Id. */
-	export type StepSansId<Steps extends Step[], Id extends Get.Id<Steps>> = Exclude<Steps[number], { id: Id }>;
+  /** Returns any Steps from the given Steps without the given Step Id. */
+  export type StepSansId<
+    Steps extends Step[],
+    Id extends Get.Id<Steps>,
+  > = Exclude<Steps[number], { id: Id }>;
 
-	/** Returns any Steps from the given Steps without the given Step Id. */
-	export type Switch<Steps extends Step[], R> = {
-		[Id in Get.Id<Steps>]?: (step: Get.StepById<Steps, Id>) => R;
-	};
+  /** Returns any Steps from the given Steps without the given Step Id. */
+  export type Switch<Steps extends Step[], R> = {
+    [Id in Get.Id<Steps>]?: (step: Get.StepById<Steps, Id>) => R;
+  };
 }
 
 /** Alias for StepperLookup (return type of generateStepperUtils). */
 export type Utils<Steps extends Step[] = Step[]> = StepperLookup<Steps>;
 
 export type {
-	Step,
-	Metadata,
-	StepStatus,
-	StepperState,
-	StepperNavigation,
-	StepperLookup,
-	StepperFlow,
-	StepperMetadata,
-	Stepper,
-	TransitionPayload,
-	Get,
-}
+  Step,
+  Metadata,
+  StepStatus,
+  StepperState,
+  StepperNavigation,
+  StepperLookup,
+  StepperFlow,
+  StepperMetadata,
+  Stepper,
+  TransitionPayload,
+  Get,
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,23 +43,32 @@ type StepperState<Steps extends Step[] = Step[]> = {
 	isTransitioning: boolean;
 };
 
+/** Optional payload for navigation (e.g. metadata to merge into transition context without waiting for setState). */
+type TransitionPayload<Steps extends Step[] = Step[]> = {
+	/** Metadata to merge into ctx.metadata for this transition and persist. */
+	metadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+};
+
 type StepperNavigation<Steps extends Step[] = Step[]> = {
 	/**
 	 * Advances to the next step.
-	 * @returns The next step.
+	 * @param payload - Optional metadata to merge into transition context (avoids stale metadata in onBeforeTransition).
+	 * @returns void or Promise when lifecycle hooks run.
 	 */
-	next: () => void | Promise<void>;
+	next: (payload?: TransitionPayload<Steps>) => void | Promise<void>;
 	/**
 	 * Returns to the previous step.
-	 * @returns The previous step.
+	 * @param payload - Optional metadata to merge into transition context.
+	 * @returns void or Promise when lifecycle hooks run.
 	 */
-	prev: () => void | Promise<void>;
+	prev: (payload?: TransitionPayload<Steps>) => void | Promise<void>;
 	/**
 	 * Navigates to a specific step by its ID.
 	 * @param id - The ID of the step to navigate to.
-	 * @returns The step to navigate to.
+	 * @param payload - Optional metadata to merge into transition context.
+	 * @returns void or Promise when lifecycle hooks run.
 	 */
-	goTo: (id: Get.Id<Steps>) => void | Promise<void>;
+	goTo: (id: Get.Id<Steps>, payload?: TransitionPayload<Steps>) => void | Promise<void>;
 	/**
 	 * Resets the stepper to its initial state.
 	 * @returns The initial state of the stepper.
@@ -192,14 +201,19 @@ type StepperMetadata<Steps extends Step[] = Step[]> = {
 
 type StepperLifecycle<Steps extends Step[] = Step[]> = {
 	/**
-	 * Called before a transition occurs.
-	 * @param cb - The callback to call before the transition occurs.
+	 * Registers a callback before each transition. Multiple callbacks are supported; returns unsubscribe.
+	 * @param cb - The callback (return false or Promise<false> to cancel transition).
+	 * @returns Unsubscribe function.
 	 */
-	onBeforeTransition: (cb: (ctx: TransitionContext<Steps>) => void | Promise<void | false>) => void;
+	onBeforeTransition: (
+		cb: (ctx: TransitionContext<Steps>) => void | Promise<void | false>,
+	) => () => void;
 	/**
-	 * Called after a transition occurs.
+	 * Registers a callback after each transition. Multiple callbacks are supported; returns unsubscribe.
+	 * @param cb - The callback.
+	 * @returns Unsubscribe function.
 	 */
-	onAfterTransition: (cb: (ctx: TransitionContext<Steps>) => void | Promise<void>) => void;
+	onAfterTransition: (cb: (ctx: TransitionContext<Steps>) => void | Promise<void>) => () => void;
 };
 
 type TransitionContext<Steps extends Step[] = Step[]> = {
@@ -308,5 +322,6 @@ export type {
 	StepperFlow,
 	StepperMetadata,
 	Stepper,
+	TransitionPayload,
 	Get,
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -136,10 +136,6 @@ export const updateStepIndex = <Steps extends Step[]>(
   }
 
   const direction = newIndex < 0 ? "prev" : "next";
-  const reason = newIndex < 0 ? "it is the first step" : "it is the last step";
-  const stepId = steps[newIndex]?.id ?? `index ${newIndex}`;
-
-  throw new Error(
-    `Cannot navigate ${direction} from step "${stepId}": ${reason}`,
-  );
+  const reason = newIndex < 0 ? "first step" : "last step";
+  throw new Error(`Cannot navigate ${direction}: ${reason}`);
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,37 +5,39 @@ import type { Get, Metadata, Step, StepperFlow, StepperLookup } from "./types";
  * @param steps - The steps to generate the utils for.
  * @returns The stepper utils.
  */
-export function generateStepperUtils<const Steps extends Step[]>(...steps: Steps) {
-	return {
-		getAll() {
-			return steps;
-		},
-		get: (id) => {
-			const step = steps.find((step) => step.id === id);
-			return step as Get.StepById<Steps, typeof id>;
-		},
-		getIndex: (id) => steps.findIndex((step) => step.id === id),
-		getByIndex: (index) => steps[index],
-		getFirst() {
-			return steps[0];
-		},
-		getLast() {
-			return steps[steps.length - 1];
-		},
-		getNext(id) {
-			return steps[steps.findIndex((step) => step.id === id) + 1];
-		},
-		getPrev(id) {
-			return steps[steps.findIndex((step) => step.id === id) - 1];
-		},
-		getNeighbors(id) {
-			const index = steps.findIndex((step) => step.id === id);
-			return {
-				prev: index > 0 ? steps[index - 1] : null,
-				next: index < steps.length - 1 ? steps[index + 1] : null,
-			};
-		},
-	} satisfies StepperLookup<Steps>;
+export function generateStepperUtils<const Steps extends Step[]>(
+  ...steps: Steps
+) {
+  return {
+    getAll() {
+      return steps;
+    },
+    get: (id) => {
+      const step = steps.find((step) => step.id === id);
+      return step as Get.StepById<Steps, typeof id>;
+    },
+    getIndex: (id) => steps.findIndex((step) => step.id === id),
+    getByIndex: (index) => steps[index],
+    getFirst() {
+      return steps[0];
+    },
+    getLast() {
+      return steps[steps.length - 1];
+    },
+    getNext(id) {
+      return steps[steps.findIndex((step) => step.id === id) + 1];
+    },
+    getPrev(id) {
+      return steps[steps.findIndex((step) => step.id === id) - 1];
+    },
+    getNeighbors(id) {
+      const index = steps.findIndex((step) => step.id === id);
+      return {
+        prev: index > 0 ? steps[index - 1] : null,
+        next: index < steps.length - 1 ? steps[index + 1] : null,
+      };
+    },
+  } satisfies StepperLookup<Steps>;
 }
 
 /**
@@ -44,11 +46,14 @@ export function generateStepperUtils<const Steps extends Step[]>(...steps: Steps
  * @param initialStep - The initial step to use.
  * @returns The initial step index for the stepper.
  */
-export function getInitialStepIndex<Steps extends Step[]>(steps: Steps, initialStep?: Get.Id<Steps>) {
-	return Math.max(
-		steps.findIndex((step) => step.id === initialStep),
-		0,
-	);
+export function getInitialStepIndex<Steps extends Step[]>(
+  steps: Steps,
+  initialStep?: Get.Id<Steps>,
+) {
+  return Math.max(
+    steps.findIndex((step) => step.id === initialStep),
+    0,
+  );
 }
 
 /**
@@ -58,16 +63,17 @@ export function getInitialStepIndex<Steps extends Step[]>(steps: Steps, initialS
  * @returns The initial metadata for the stepper.
  */
 export function getInitialMetadata<Steps extends Step[]>(
-	steps: Steps,
-	initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>,
+  steps: Steps,
+  initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>,
 ) {
-	return steps.reduce(
-		(acc, step) => {
-			acc[step.id as Get.Id<Steps>] = initialMetadata?.[step.id as Get.Id<Steps>] ?? null;
-			return acc;
-		},
-		{} as Record<Get.Id<Steps>, Metadata>,
-	);
+  return steps.reduce(
+    (acc, step) => {
+      acc[step.id as Get.Id<Steps>] =
+        initialMetadata?.[step.id as Get.Id<Steps>] ?? null;
+      return acc;
+    },
+    {} as Record<Get.Id<Steps>, Metadata>,
+  );
 }
 
 /**
@@ -78,33 +84,37 @@ export function getInitialMetadata<Steps extends Step[]>(
  * @returns The common stepper use functions.
  */
 export function generateCommonStepperUseFns<const Steps extends Step[]>(
-	steps: Steps,
-	currentStep: Steps[number],
-	stepIndex: number,
+  steps: Steps,
+  currentStep: Steps[number],
+  stepIndex: number,
 ): StepperFlow<Steps> {
-	return {
-		switch(when) {
-			const whenFn = when[currentStep.id as keyof typeof when];
-			return whenFn?.(currentStep as Get.StepById<typeof steps, (typeof currentStep)["id"]>);
-		},
-		when(id, whenFn, elseFn) {
-			const currentStep = steps[stepIndex];
-			const matchesId = Array.isArray(id)
-				? currentStep.id === id[0] && id.slice(1).every(Boolean)
-				: currentStep.id === id;
+  return {
+    switch(when) {
+      const whenFn = when[currentStep.id as keyof typeof when];
+      return whenFn?.(
+        currentStep as Get.StepById<typeof steps, (typeof currentStep)["id"]>,
+      );
+    },
+    when(id, whenFn, elseFn) {
+      const currentStep = steps[stepIndex];
+      const matchesId = Array.isArray(id)
+        ? currentStep.id === id[0] && id.slice(1).every(Boolean)
+        : currentStep.id === id;
 
-			return matchesId ? whenFn?.(currentStep as any) : elseFn?.(currentStep as any);
-		},
-		match(state, matches) {
-			const step = steps.find((s) => s.id === state);
-			if (!step) return null;
-			const matchFn = matches[state as keyof typeof matches];
-			return matchFn?.(step as any) ?? null;
-		},
-		is(id) {
-			return currentStep.id === id;
-		},
-	} as StepperFlow<Steps>;
+      return matchesId
+        ? whenFn?.(currentStep as any)
+        : elseFn?.(currentStep as any);
+    },
+    match(state, matches) {
+      const step = steps.find((s) => s.id === state);
+      if (!step) return null;
+      const matchFn = matches[state as keyof typeof matches];
+      return matchFn?.(step as any) ?? null;
+    },
+    is(id) {
+      return currentStep.id === id;
+    },
+  } as StepperFlow<Steps>;
 }
 
 /**
@@ -114,27 +124,40 @@ export function generateCommonStepperUseFns<const Steps extends Step[]>(
  * @param setter - The setter to update the step index with.
  */
 export const updateStepIndex = <Steps extends Step[]>(
-	steps: Steps,
-	newIndex: number,
-	setter: (index: number) => void,
+  steps: Steps,
+  newIndex: number,
+  setter: (index: number) => void,
 ) => {
-	if (newIndex < 0) throwNavigationError({ steps, newIndex, direction: "next", reason: "it is the first step" });
-	if (newIndex >= steps.length)
-		throwNavigationError({ steps, newIndex, direction: "prev", reason: "it is the last step" });
-	setter(newIndex);
+  if (newIndex < 0)
+    throwNavigationError({
+      steps,
+      newIndex,
+      direction: "next",
+      reason: "it is the first step",
+    });
+  if (newIndex >= steps.length)
+    throwNavigationError({
+      steps,
+      newIndex,
+      direction: "prev",
+      reason: "it is the last step",
+    });
+  setter(newIndex);
 };
 
 const throwNavigationError = ({
-	steps,
-	newIndex,
-	direction,
-	reason,
+  steps,
+  newIndex,
+  direction,
+  reason,
 }: {
-	steps: Step[];
-	newIndex: number;
-	direction: "next" | "prev";
-	reason: string;
+  steps: Step[];
+  newIndex: number;
+  direction: "next" | "prev";
+  reason: string;
 }) => {
-	const stepId = steps[newIndex]?.id ?? `index ${newIndex}`;
-	throw new Error(`Cannot navigate ${direction} from step "${stepId}": ${reason}`);
+  const stepId = steps[newIndex]?.id ?? `index ${newIndex}`;
+  throw new Error(
+    `Cannot navigate ${direction} from step "${stepId}": ${reason}`,
+  );
 };

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,17 +1,17 @@
 {
-	"compilerOptions": {
-		"outDir": "dist",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"removeComments": false,
-		"module": "esnext",
-		"target": "esnext",
-		"moduleResolution": "bundler",
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"strict": true
-	},
-	"include": ["."],
-	"exclude": ["node_modules", "dist"]
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+  },
+  "include": ["."],
+  "exclude": ["node_modules", "dist"],
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -12,9 +12,14 @@ export default defineConfig({
   tsconfig: "tsconfig.json",
   terserOptions: {
     compress: {
+      module: true,
+      passes: 3,
+      pure_getters: true,
       drop_console: true,
       pure_funcs: ["console.info", "console.debug"],
     },
-    mangle: true,
+    mangle: {
+      toplevel: true,
+    },
   },
 });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,20 +1,20 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
-	format: ["esm"],
-	dts: true,
-	sourcemap: false,
-	clean: true,
-	minify: "terser",
-	treeshake: true,
-	splitting: true,
-	tsconfig: "tsconfig.json",
-	terserOptions: {
-		compress: {
-			drop_console: true,
-			pure_funcs: ["console.info", "console.debug"],
-		},
-		mangle: true,
-	},
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: false,
+  clean: true,
+  minify: "terser",
+  treeshake: true,
+  splitting: true,
+  tsconfig: "tsconfig.json",
+  terserOptions: {
+    compress: {
+      drop_console: true,
+      pure_funcs: ["console.info", "console.debug"],
+    },
+    mangle: true,
+  },
 });

--- a/packages/react/src/define-stepper.ts
+++ b/packages/react/src/define-stepper.ts
@@ -151,7 +151,7 @@ export const defineStepper = <const Steps extends Step[]>(
       };
       const goTo = (id: Get.Id<Steps>, payload?: TransitionPayload<Steps>) => {
         const toIndex = steps.findIndex((s) => s.id === id);
-        if (toIndex === -1) throw new Error(`Step with id "${id}" not found.`);
+        if (toIndex === -1) throw new Error(`Step "${id}" not found.`);
         if (toIndex === stepIndex) return;
         if (hasLifecycle() || payload?.metadata) {
           return performTransition(stepIndex, toIndex, "goTo", payload);

--- a/packages/react/src/define-stepper.ts
+++ b/packages/react/src/define-stepper.ts
@@ -1,27 +1,29 @@
 import type {
-	Get,
-	Metadata,
-	Step,
-	Stepper,
-	StepStatus,
-	TransitionPayload,
+  Get,
+  Metadata,
+  Step,
+  Stepper,
+  StepStatus,
+  TransitionPayload,
 } from "@stepperize/core";
 import {
-	generateCommonStepperUseFns,
-	generateStepperUtils,
-	getInitialMetadata,
-	getInitialStepIndex,
-	updateStepIndex,
+  generateCommonStepperUseFns,
+  generateStepperUtils,
+  getInitialMetadata,
+  getInitialStepIndex,
+  updateStepIndex,
 } from "@stepperize/core";
-import * as React from "react";
+import React from "react";
 import { createStepperPrimitives } from "./primitives/create-stepper-primitives";
 import type { ScopedProps, StepperReturn, TransitionContext } from "./types";
 import { getStatuses } from "./utils";
 
 type BeforeCb<Steps extends Step[]> = (
-	ctx: TransitionContext<Steps>,
-) => void | Promise<void | false>;
-type AfterCb<Steps extends Step[]> = (ctx: TransitionContext<Steps>) => void | Promise<void>;
+  ctx: TransitionContext<Steps>,
+) => false | void | Promise<void | false>;
+type AfterCb<Steps extends Step[]> = (
+  ctx: TransitionContext<Steps>,
+) => void | Promise<void>;
 
 /**
  * Creates a stepper context and utility functions for managing stepper state.
@@ -29,193 +31,219 @@ type AfterCb<Steps extends Step[]> = (ctx: TransitionContext<Steps>) => void | P
  * @param steps - The steps to be included in the stepper.
  * @returns An object containing the stepper context and utility functions.
  */
-export const defineStepper = <const Steps extends Step[]>(...steps: Steps): StepperReturn<Steps> => {
-	const Context = React.createContext<
-			Stepper<Steps> | null
-		>(null);
+export const defineStepper = <const Steps extends Step[]>(
+  ...steps: Steps
+): StepperReturn<Steps> => {
+  const Context = React.createContext<Stepper<Steps> | null>(null);
 
-	const useStepper = (config?: {
-		initialStep?: Get.Id<Steps>;
-		initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
-	}) => {
-		const { initialStep, initialMetadata } = config ?? {};
-		const initialStepIndex = React.useMemo(() => getInitialStepIndex(steps, initialStep), [initialStep]);
+  const useStepper = (config?: {
+    initialStep?: Get.Id<Steps>;
+    initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+  }) => {
+    const { initialStep, initialMetadata } = config ?? {};
+    const initialStepIndex = React.useMemo(
+      () => getInitialStepIndex(steps, initialStep),
+      [initialStep],
+    );
 
-		const [stepIndex, setStepIndex] = React.useState(initialStepIndex);
-		const [metadata, setMetadata] = React.useState(() => getInitialMetadata(steps, initialMetadata));
-		const [isTransitioning, setIsTransitioning] = React.useState(false);
+    const [stepIndex, setStepIndex] = React.useState(initialStepIndex);
+    const [metadata, setMetadata] = React.useState(() =>
+      getInitialMetadata(steps, initialMetadata),
+    );
+    const [isTransitioning, setIsTransitioning] = React.useState(false);
 
-		const beforeCallbacksRef = React.useRef<BeforeCb<Steps>[]>([]);
-		const afterCallbacksRef = React.useRef<AfterCb<Steps>[]>([]);
+    const beforeCallbacksRef = React.useRef<BeforeCb<Steps>[]>([]);
+    const afterCallbacksRef = React.useRef<AfterCb<Steps>[]>([]);
 
-		const performTransition = React.useCallback(
-			async (
-				fromIndex: number,
-				toIndex: number,
-				direction: "next" | "prev" | "goTo",
-				payload?: TransitionPayload<Steps>,
-			) => {
-				setIsTransitioning(true);
-				try {
-					const from = steps[fromIndex];
-					const to = steps[toIndex];
-					const effectiveMetadata = {
-						...metadata,
-						...(payload?.metadata ?? {}),
-					} as Record<Get.Id<Steps>, Metadata>;
-					const ctx: TransitionContext<Steps> = {
-						from,
-						to,
-						metadata: effectiveMetadata,
-						statuses: getStatuses(steps, fromIndex),
-						direction,
-						fromIndex,
-						toIndex,
-					};
-					for (const cb of beforeCallbacksRef.current) {
-						const proceed = await cb(ctx);
-						if (proceed === false) return;
-					}
-					if (payload?.metadata) {
-						setMetadata((prev) => ({ ...prev, ...payload.metadata }));
-					}
-					setStepIndex(toIndex);
-					const ctxAfter: TransitionContext<Steps> = {
-						...ctx,
-						statuses: getStatuses(steps, toIndex),
-					};
-					for (const cb of afterCallbacksRef.current) {
-						await cb(ctxAfter);
-					}
-				} finally {
-					setIsTransitioning(false);
-				}
-			},
-			[metadata],
-		);
+    const performTransition = React.useCallback(
+      async (
+        fromIndex: number,
+        toIndex: number,
+        direction: "next" | "prev" | "goTo",
+        payload?: TransitionPayload<Steps>,
+      ) => {
+        setIsTransitioning(true);
+        try {
+          const from = steps[fromIndex];
+          const to = steps[toIndex];
+          const effectiveMetadata = {
+            ...metadata,
+            ...(payload?.metadata ?? {}),
+          } as Record<Get.Id<Steps>, Metadata>;
+          const ctx: TransitionContext<Steps> = {
+            from,
+            to,
+            metadata: effectiveMetadata,
+            statuses: getStatuses(steps, fromIndex),
+            direction,
+            fromIndex,
+            toIndex,
+          };
+          for (const cb of beforeCallbacksRef.current) {
+            const proceed = await cb(ctx);
+            if (proceed === false) return;
+          }
+          if (payload?.metadata) {
+            setMetadata((prev) => ({ ...prev, ...payload.metadata }));
+          }
+          setStepIndex(toIndex);
+          const ctxAfter: TransitionContext<Steps> = {
+            ...ctx,
+            statuses: getStatuses(steps, toIndex),
+          };
+          for (const cb of afterCallbacksRef.current) {
+            await cb(ctxAfter);
+          }
+        } finally {
+          setIsTransitioning(false);
+        }
+      },
+      [metadata],
+    );
 
-		const stepper = React.useMemo(() => {
-			const current = steps[stepIndex];
-			const isLast = stepIndex === steps.length - 1;
-			const isFirst = stepIndex === 0;
-			const status: StepStatus = "active";
+    const stepper = React.useMemo(() => {
+      const current = steps[stepIndex];
+      const isLast = stepIndex === steps.length - 1;
+      const isFirst = stepIndex === 0;
+      const status: StepStatus = "active";
 
-			const hasLifecycle = () =>
-				beforeCallbacksRef.current.length > 0 || afterCallbacksRef.current.length > 0;
+      const hasLifecycle = () =>
+        beforeCallbacksRef.current.length > 0 ||
+        afterCallbacksRef.current.length > 0;
 
-			const next = (payload?: TransitionPayload<Steps>) => {
-				const toIndex = stepIndex + 1;
-				if (hasLifecycle() || payload?.metadata) {
-					if (toIndex >= steps.length) return;
-					return performTransition(stepIndex, toIndex, "next", payload);
-				}
-				updateStepIndex(steps, toIndex, setStepIndex);
-			};
-			const prev = (payload?: TransitionPayload<Steps>) => {
-				const toIndex = stepIndex - 1;
-				if (hasLifecycle() || payload?.metadata) {
-					if (toIndex < 0) return;
-					return performTransition(stepIndex, toIndex, "prev", payload);
-				}
-				updateStepIndex(steps, toIndex, setStepIndex);
-			};
-			const goTo = (id: Get.Id<Steps>, payload?: TransitionPayload<Steps>) => {
-				const toIndex = steps.findIndex((s) => s.id === id);
-				if (toIndex === -1) throw new Error(`Step with id "${id}" not found.`);
-				if (toIndex === stepIndex) return;
-				if (hasLifecycle() || payload?.metadata) {
-					return performTransition(stepIndex, toIndex, "goTo", payload);
-				}
-				setStepIndex(toIndex);
-			};
-			const reset = () => {
-				updateStepIndex(steps, getInitialStepIndex(steps, initialStep), setStepIndex);
-			};
+      const next = (payload?: TransitionPayload<Steps>) => {
+        const toIndex = stepIndex + 1;
+        if (hasLifecycle() || payload?.metadata) {
+          if (toIndex >= steps.length) return;
+          return performTransition(stepIndex, toIndex, "next", payload);
+        }
+        updateStepIndex(steps, toIndex, setStepIndex);
+      };
+      const prev = (payload?: TransitionPayload<Steps>) => {
+        const toIndex = stepIndex - 1;
+        if (hasLifecycle() || payload?.metadata) {
+          if (toIndex < 0) return;
+          return performTransition(stepIndex, toIndex, "prev", payload);
+        }
+        updateStepIndex(steps, toIndex, setStepIndex);
+      };
+      const goTo = (id: Get.Id<Steps>, payload?: TransitionPayload<Steps>) => {
+        const toIndex = steps.findIndex((s) => s.id === id);
+        if (toIndex === -1) throw new Error(`Step with id "${id}" not found.`);
+        if (toIndex === stepIndex) return;
+        if (hasLifecycle() || payload?.metadata) {
+          return performTransition(stepIndex, toIndex, "goTo", payload);
+        }
+        setStepIndex(toIndex);
+      };
+      const reset = () => {
+        updateStepIndex(
+          steps,
+          getInitialStepIndex(steps, initialStep),
+          setStepIndex,
+        );
+      };
 
-			return {
-				state: {
-					all: steps,
-					current: {
-						data: current,
-						index: stepIndex,
-						status,
-						metadata: {
-							get: () => metadata[current.id as Get.Id<Steps>],
-							set: (values) => {
-								setMetadata((prev) =>
-									prev[current.id as Get.Id<Steps>] === values
-										? prev
-										: { ...prev, [current.id as Get.Id<Steps>]: values },
-								);
-							},
-							reset: (keepInitialMetadata?: boolean) => {
-								setMetadata(
-									getInitialMetadata(steps, keepInitialMetadata ? initialMetadata : undefined),
-								);
-							},
-						},
-					},
-					isLast,
-					isFirst,
-					isTransitioning,
-				},
-				navigation: { next, prev, goTo, reset },
-				lookup: generateStepperUtils(...steps),
-				flow: generateCommonStepperUseFns(steps, current, stepIndex),
-				metadata: {
-					get values() {
-						return metadata;
-					},
-					set: (id, values) => {
-						setMetadata((prev) => (prev[id] === values ? prev : { ...prev, [id]: values }));
-					},
-					get: (id) => metadata[id],
-					reset: (keepInitialMetadata?: boolean) => {
-						setMetadata(
-							getInitialMetadata(steps, keepInitialMetadata ? initialMetadata : undefined),
-						);
-					},
-				},
-				lifecycle: {
-					onBeforeTransition(cb: BeforeCb<Steps>) {
-						const list = beforeCallbacksRef.current;
-						list.push(cb);
-						return () => {
-							const i = list.indexOf(cb);
-							if (i !== -1) list.splice(i, 1);
-						};
-					},
-					onAfterTransition(cb: AfterCb<Steps>) {
-						const list = afterCallbacksRef.current;
-						list.push(cb);
-						return () => {
-							const i = list.indexOf(cb);
-							if (i !== -1) list.splice(i, 1);
-						};
-					},
-				},
-			} as Stepper<Steps>;
-		}, [stepIndex, metadata, isTransitioning, performTransition]);
+      return {
+        state: {
+          all: steps,
+          current: {
+            data: current,
+            index: stepIndex,
+            status,
+            metadata: {
+              get: () => metadata[current.id as Get.Id<Steps>],
+              set: (values) => {
+                setMetadata((prev) =>
+                  prev[current.id as Get.Id<Steps>] === values
+                    ? prev
+                    : { ...prev, [current.id as Get.Id<Steps>]: values },
+                );
+              },
+              reset: (keepInitialMetadata?: boolean) => {
+                setMetadata(
+                  getInitialMetadata(
+                    steps,
+                    keepInitialMetadata ? initialMetadata : undefined,
+                  ),
+                );
+              },
+            },
+          },
+          isLast,
+          isFirst,
+          isTransitioning,
+        },
+        navigation: { next, prev, goTo, reset },
+        lookup: generateStepperUtils(...steps),
+        flow: generateCommonStepperUseFns(steps, current, stepIndex),
+        metadata: {
+          get values() {
+            return metadata;
+          },
+          set: (id, values) => {
+            setMetadata((prev) =>
+              prev[id] === values ? prev : { ...prev, [id]: values },
+            );
+          },
+          get: (id) => metadata[id],
+          reset: (keepInitialMetadata?: boolean) => {
+            setMetadata(
+              getInitialMetadata(
+                steps,
+                keepInitialMetadata ? initialMetadata : undefined,
+              ),
+            );
+          },
+        },
+        lifecycle: {
+          onBeforeTransition(cb: BeforeCb<Steps>) {
+            const list = beforeCallbacksRef.current;
+            list.push(cb);
+            return () => {
+              const i = list.indexOf(cb);
+              if (i !== -1) list.splice(i, 1);
+            };
+          },
+          onAfterTransition(cb: AfterCb<Steps>) {
+            const list = afterCallbacksRef.current;
+            list.push(cb);
+            return () => {
+              const i = list.indexOf(cb);
+              if (i !== -1) list.splice(i, 1);
+            };
+          },
+        },
+      } as Stepper<Steps>;
+    }, [stepIndex, metadata, isTransitioning, performTransition]);
 
-		return stepper;
-	};
+    return stepper;
+  };
 
-	const ScopedProvider = ({ initialStep, initialMetadata, children }: ScopedProps<Steps>) =>
-		React.createElement(
-			Context.Provider,
-			{ value: useStepper({ initialStep, initialMetadata }) },
-			children,
-		);
+  const ScopedProvider = ({
+    initialStep,
+    initialMetadata,
+    children,
+  }: ScopedProps<Steps>) =>
+    React.createElement(
+      Context.Provider,
+      { value: useStepper({ initialStep, initialMetadata }) },
+      children,
+    );
 
-	const Stepper = createStepperPrimitives(
-		Context as React.Context<Stepper<Steps> | null>,
-		ScopedProvider,
-	);
+  const Stepper = createStepperPrimitives(
+    Context as React.Context<Stepper<Steps> | null>,
+    ScopedProvider,
+  );
 
-	return {
-		steps,
-		Scoped: ScopedProvider,
-		useStepper: (props = {}) => React.useContext(Context) ?? useStepper(props),
-		Stepper,
-	};
+  return {
+    steps,
+    Scoped: ScopedProvider,
+    useStepper: (props = {}) => {
+      const fromContext = React.useContext(Context);
+      const fromHook = useStepper(props);
+      return fromContext ?? fromHook;
+    },
+    Stepper,
+  };
 };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,10 +1,10 @@
 // Types
 export type { Get, Step, Stepper, TransitionPayload } from "@stepperize/core";
-export type {
-	StepperReturn,
-	ScopedProps,
-	TransitionContext,
-	TransitionDirection,
-} from "./types";
 // Define Stepper
 export * from "./define-stepper";
+export type {
+  ScopedProps,
+  StepperReturn,
+  TransitionContext,
+  TransitionDirection,
+} from "./types";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 // Types
-export type { Step, Stepper, Get } from "@stepperize/core";
+export type { Get, Step, Stepper, TransitionPayload } from "@stepperize/core";
 export type {
 	StepperReturn,
 	ScopedProps,

--- a/packages/react/src/primitives/actions.tsx
+++ b/packages/react/src/primitives/actions.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
 import type { ActionsProps } from "./types";
 
 export function createActions() {
-	return function Actions(props: ActionsProps) {
-		const { render, children, ...rest } = props;
-		const domProps = {
-			"data-component": "stepper-actions",
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("div", domProps, children);
-	};
+  return function Actions(props: ActionsProps) {
+    const { render, children, ...rest } = props;
+    const domProps = {
+      "data-component": "stepper-actions",
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <div {...domProps}>{children}</div>;
+  };
 }

--- a/packages/react/src/primitives/content.tsx
+++ b/packages/react/src/primitives/content.tsx
@@ -1,5 +1,5 @@
 import type { Step, Stepper } from "@stepperize/core";
-import React from "react";
+import type React from "react";
 import { useStepperContextOrThrow } from "./helpers";
 import type { ContentProps } from "./types";
 

--- a/packages/react/src/primitives/content.tsx
+++ b/packages/react/src/primitives/content.tsx
@@ -1,30 +1,30 @@
-import * as React from "react";
 import type { Step, Stepper } from "@stepperize/core";
+import React from "react";
 import type { ContentProps } from "./types";
 
 export function createContent<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
+  StepperContext: React.Context<Stepper<Steps> | null>,
 ) {
-	return function Content(props: ContentProps<Steps>) {
-		const { step, render, children, ...rest } = props;
-		const stepper = React.useContext(StepperContext);
-		if (!stepper) {
-			throw new Error("Stepper.Content must be used within Stepper.Root.");
-		}
-		const isActive = stepper.state.current.data.id === step;
-		if (!isActive) {
-			return null;
-		}
-		const domProps = {
-			id: `step-panel-${step}`,
-			"data-component": "stepper-content",
-			role: "tabpanel" as const,
-			"aria-labelledby": `step-${step}`,
-			"aria-hidden": false,
-			tabIndex: 0,
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("div", domProps, children);
-	};
+  return function Content(props: ContentProps<Steps>) {
+    const { step, render, children, ...rest } = props;
+    const stepper = React.useContext(StepperContext);
+    if (!stepper) {
+      throw new Error("Stepper.Content must be used within Stepper.Root.");
+    }
+    const isActive = stepper.state.current.data.id === step;
+    if (!isActive) {
+      return null;
+    }
+    const domProps = {
+      id: `step-panel-${step}`,
+      "data-component": "stepper-content",
+      role: "tabpanel" as const,
+      "aria-labelledby": `step-${step}`,
+      "aria-hidden": false,
+      tabIndex: 0,
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <div {...domProps}>{children}</div>;
+  };
 }

--- a/packages/react/src/primitives/content.tsx
+++ b/packages/react/src/primitives/content.tsx
@@ -1,5 +1,6 @@
 import type { Step, Stepper } from "@stepperize/core";
 import React from "react";
+import { useStepperContextOrThrow } from "./helpers";
 import type { ContentProps } from "./types";
 
 export function createContent<Steps extends Step[]>(
@@ -7,10 +8,7 @@ export function createContent<Steps extends Step[]>(
 ) {
   return function Content(props: ContentProps<Steps>) {
     const { step, render, children, ...rest } = props;
-    const stepper = React.useContext(StepperContext);
-    if (!stepper) {
-      throw new Error("Stepper.Content must be used within Stepper.Root.");
-    }
+    const stepper = useStepperContextOrThrow(StepperContext);
     const isActive = stepper.state.current.data.id === step;
     if (!isActive) {
       return null;
@@ -20,7 +18,6 @@ export function createContent<Steps extends Step[]>(
       "data-component": "stepper-content",
       role: "tabpanel" as const,
       "aria-labelledby": `step-${step}`,
-      "aria-hidden": false,
       tabIndex: 0,
       ...rest,
     };

--- a/packages/react/src/primitives/context.ts
+++ b/packages/react/src/primitives/context.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
 import type { Step, StepperState } from "@stepperize/core";
+import React from "react";
 
 /**
  * Value provided to children of `Stepper.Item`. Same shape as `useStepper().state.current`:
@@ -10,13 +10,13 @@ export type StepItemValue<S extends Step = Step> = StepperState<[S]>["current"];
 const StepItemContext = React.createContext<StepItemValue | null>(null);
 
 export function StepItemProvider<S extends Step>({
-	value,
-	children,
+  value,
+  children,
 }: {
-	value: StepItemValue<S>;
-	children: React.ReactNode;
+  value: StepItemValue<S>;
+  children: React.ReactNode;
 }) {
-	return React.createElement(StepItemContext.Provider, { value, children });
+  return React.createElement(StepItemContext.Provider, { value, children });
 }
 
 /**
@@ -49,11 +49,11 @@ export function StepItemProvider<S extends Step>({
  * ```
  */
 export function useStepItemContext<S extends Step = Step>(): StepItemValue<S> {
-	const context = React.useContext(StepItemContext);
-	if (!context) {
-		throw new Error("useStepItemContext must be used within a Stepper.Item.");
-	}
-	return context as StepItemValue<S>;
+  const context = React.useContext(StepItemContext);
+  if (!context) {
+    throw new Error("useStepItemContext must be used within a Stepper.Item.");
+  }
+  return context as StepItemValue<S>;
 }
 
 export { StepItemContext };

--- a/packages/react/src/primitives/context.ts
+++ b/packages/react/src/primitives/context.ts
@@ -51,7 +51,7 @@ export function StepItemProvider<S extends Step>({
 export function useStepItemContext<S extends Step = Step>(): StepItemValue<S> {
   const context = React.useContext(StepItemContext);
   if (!context) {
-    throw new Error("useStepItemContext must be used within a Stepper.Item.");
+    throw new Error("Missing Stepper.Item.");
   }
   return context as StepItemValue<S>;
 }

--- a/packages/react/src/primitives/create-stepper-primitives.tsx
+++ b/packages/react/src/primitives/create-stepper-primitives.tsx
@@ -1,54 +1,55 @@
-import * as React from "react";
-import type { Get, Metadata, Step, Stepper, Utils } from "@stepperize/core";
-import { createRoot } from "./root";
-import { createList } from "./list";
-import { createItem } from "./item";
-import { createTrigger } from "./trigger";
-import { createTitle } from "./title";
+import type { Get, Metadata, Step, Stepper } from "@stepperize/core";
+import type React from "react";
+import { createActions } from "./actions";
+import { createContent } from "./content";
 import { createDescription } from "./description";
 import { createIndicator } from "./indicator";
-import { createSeparator } from "./separator";
-import { createContent } from "./content";
-import { createActions } from "./actions";
-import { createPrev } from "./prev";
+import { createItem } from "./item";
+import { createList } from "./list";
 import { createNext } from "./next";
+import { createPrev } from "./prev";
+import { createRoot } from "./root";
+import { createSeparator } from "./separator";
+import { createTitle } from "./title";
+import { createTrigger } from "./trigger";
 
 export type StepperPrimitives<Steps extends Step[]> = {
-	Root: ReturnType<typeof createRoot<Steps>>;
-	List: ReturnType<typeof createList>;
-	Item: ReturnType<typeof createItem<Steps>>;
-	Trigger: ReturnType<typeof createTrigger<Steps>>;
-	Title: ReturnType<typeof createTitle>;
-	Description: ReturnType<typeof createDescription<Steps>>;
-	Indicator: ReturnType<typeof createIndicator<Steps>>;
-	Separator: ReturnType<typeof createSeparator>;
-	Content: ReturnType<typeof createContent<Steps>>;
-	Actions: ReturnType<typeof createActions>;
-	Prev: ReturnType<typeof createPrev<Steps>>;
-	Next: ReturnType<typeof createNext<Steps>>;
+  Root: ReturnType<typeof createRoot<Steps>>;
+  List: ReturnType<typeof createList>;
+  Item: ReturnType<typeof createItem<Steps>>;
+  Trigger: ReturnType<typeof createTrigger<Steps>>;
+  Title: ReturnType<typeof createTitle>;
+  Description: ReturnType<typeof createDescription>;
+  Indicator: ReturnType<typeof createIndicator>;
+  Separator: ReturnType<typeof createSeparator>;
+  Content: ReturnType<typeof createContent<Steps>>;
+  Actions: ReturnType<typeof createActions>;
+  Prev: ReturnType<typeof createPrev<Steps>>;
+  Next: ReturnType<typeof createNext<Steps>>;
 };
 
-export type ScopedProviderProps<Steps extends Step[]> = React.PropsWithChildren<{
-	initialStep?: Get.Id<Steps>;
-	initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
-}>;
+export type ScopedProviderProps<Steps extends Step[]> =
+  React.PropsWithChildren<{
+    initialStep?: Get.Id<Steps>;
+    initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+  }>;
 
 export function createStepperPrimitives<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
-	ScopedProvider: (props: ScopedProviderProps<Steps>) => React.ReactElement,
+  StepperContext: React.Context<Stepper<Steps> | null>,
+  ScopedProvider: (props: ScopedProviderProps<Steps>) => React.ReactElement,
 ): StepperPrimitives<Steps> {
-	return {
-		Root: createRoot(StepperContext, ScopedProvider),
-		List: createList(StepperContext),
-		Item: createItem(StepperContext),
-		Trigger: createTrigger(StepperContext),
-		Title: createTitle(),
-		Description: createDescription(),
-		Indicator: createIndicator(),
-		Separator: createSeparator(),
-		Content: createContent(StepperContext),
-		Actions: createActions(),
-		Prev: createPrev(StepperContext),
-		Next: createNext(StepperContext),
-	};
+  return {
+    Root: createRoot(StepperContext, ScopedProvider),
+    List: createList(StepperContext),
+    Item: createItem(StepperContext),
+    Trigger: createTrigger(StepperContext),
+    Title: createTitle(),
+    Description: createDescription(),
+    Indicator: createIndicator(),
+    Separator: createSeparator(),
+    Content: createContent(StepperContext),
+    Actions: createActions(),
+    Prev: createPrev(StepperContext),
+    Next: createNext(StepperContext),
+  };
 }

--- a/packages/react/src/primitives/description.tsx
+++ b/packages/react/src/primitives/description.tsx
@@ -1,15 +1,13 @@
-import * as React from "react";
-import type { Step } from "@stepperize/core";
 import type { DescriptionProps } from "./types";
 
-export function createDescription<Steps extends Step[]>() {
-	return function Description(props: DescriptionProps) {
-		const { render, children, ...rest } = props;
-		const domProps = {
-			"data-component": "stepper-description",
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("p", domProps, children);
-	};
+export function createDescription() {
+  return function Description(props: DescriptionProps) {
+    const { render, children, ...rest } = props;
+    const domProps = {
+      "data-component": "stepper-description",
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <p {...domProps}>{children}</p>;
+  };
 }

--- a/packages/react/src/primitives/helpers.ts
+++ b/packages/react/src/primitives/helpers.ts
@@ -1,0 +1,22 @@
+import type { Step, Stepper } from "@stepperize/core";
+import React from "react";
+
+export function useStepperContextOrThrow<Steps extends Step[]>(
+  StepperContext: React.Context<Stepper<Steps> | null>,
+) {
+  const stepper = React.useContext(StepperContext);
+  if (!stepper) {
+    throw new Error("Missing Stepper.Root.");
+  }
+  return stepper;
+}
+
+export function runClickHandler(
+  event: React.MouseEvent<HTMLButtonElement>,
+  onClick: React.MouseEventHandler<HTMLButtonElement> | undefined,
+  action: () => void,
+) {
+  onClick?.(event);
+  if (event.defaultPrevented) return;
+  action();
+}

--- a/packages/react/src/primitives/index.ts
+++ b/packages/react/src/primitives/index.ts
@@ -66,27 +66,30 @@
  * ```
  */
 
-export { useStepItemContext, StepItemProvider, StepItemContext } from "./context";
 export type { StepItemValue } from "./context";
-
-export type {
-	StepStatus,
-	StepInfo,
-	RenderProp,
-	PrimitiveProps,
-	RootProps,
-	ListProps,
-	ItemProps,
-	TriggerProps,
-	TitleProps,
-	DescriptionProps,
-	IndicatorProps,
-	SeparatorProps,
-	ContentProps,
-	ActionsProps,
-	PrevProps,
-	NextProps,
-} from "./types";
+export {
+  StepItemContext,
+  StepItemProvider,
+  useStepItemContext,
+} from "./context";
+export type { StepperPrimitives } from "./create-stepper-primitives";
 
 export { createStepperPrimitives } from "./create-stepper-primitives";
-export type { StepperPrimitives } from "./create-stepper-primitives";
+export type {
+  ActionsProps,
+  ContentProps,
+  DescriptionProps,
+  IndicatorProps,
+  ItemProps,
+  ListProps,
+  NextProps,
+  PrevProps,
+  PrimitiveProps,
+  RenderProp,
+  RootProps,
+  SeparatorProps,
+  StepInfo,
+  StepStatus,
+  TitleProps,
+  TriggerProps,
+} from "./types";

--- a/packages/react/src/primitives/indicator.tsx
+++ b/packages/react/src/primitives/indicator.tsx
@@ -1,18 +1,23 @@
-import * as React from "react";
-import type { Step } from "@stepperize/core";
-import type { IndicatorProps } from "./types";
+import type React from "react";
 import { useStepItemContext } from "./context";
+import type { IndicatorProps } from "./types";
 
-export function createIndicator<Steps extends Step[]>() {
-	return function Indicator(props: IndicatorProps) {
-		const { render, children, ...rest } = props;
-		const item = useStepItemContext();
-		const merged = {
-			"data-component": "stepper-indicator",
-			"data-status": item.status,
-			...rest,
-		};
-		const content = render ? render(merged as React.ComponentPropsWithoutRef<"span">) : children;
-		return React.createElement("span", { "aria-hidden": true, ...merged }, content);
-	};
+export function createIndicator() {
+  return function Indicator(props: IndicatorProps) {
+    const { render, children, ...rest } = props;
+    const item = useStepItemContext();
+    const merged = {
+      "data-component": "stepper-indicator",
+      "data-status": item.status,
+      ...rest,
+    };
+    const content = render
+      ? render(merged as React.ComponentPropsWithoutRef<"span">)
+      : children;
+    return (
+      <span aria-hidden={true} {...merged}>
+        {content}
+      </span>
+    );
+  };
 }

--- a/packages/react/src/primitives/item.tsx
+++ b/packages/react/src/primitives/item.tsx
@@ -1,5 +1,6 @@
 import type { Get, Metadata, Step, Stepper } from "@stepperize/core";
 import React from "react";
+import { useStepperContextOrThrow } from "./helpers";
 import { StepItemProvider, type StepItemValue } from "./context";
 import type { ItemProps, StepStatus } from "./types";
 
@@ -8,10 +9,7 @@ export function createItem<Steps extends Step[]>(
 ) {
   return function Item(props: ItemProps<Steps>) {
     const { step, render, children, ...rest } = props;
-    const stepper = React.useContext(StepperContext);
-    if (!stepper) {
-      throw new Error("Stepper.Item must be used within Stepper.Root.");
-    }
+    const stepper = useStepperContextOrThrow(StepperContext);
     const stepIndex = stepper.lookup.getIndex(step);
     const currentIndex = stepper.state.current.index;
     const status: StepStatus =

--- a/packages/react/src/primitives/item.tsx
+++ b/packages/react/src/primitives/item.tsx
@@ -42,7 +42,11 @@ export function createItem<Steps extends Step[]>(
       ...rest,
     };
     if (render) {
-      <StepItemProvider value={itemValue}>{render(domProps)}</StepItemProvider>;
+      return (
+        <StepItemProvider value={itemValue}>
+          {render(domProps)}
+        </StepItemProvider>
+      );
     }
     return (
       <StepItemProvider value={itemValue}>

--- a/packages/react/src/primitives/item.tsx
+++ b/packages/react/src/primitives/item.tsx
@@ -1,51 +1,53 @@
-import * as React from "react";
 import type { Get, Metadata, Step, Stepper } from "@stepperize/core";
-import type { ItemProps, StepStatus } from "./types";
+import React from "react";
 import { StepItemProvider, type StepItemValue } from "./context";
+import type { ItemProps, StepStatus } from "./types";
 
 export function createItem<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
+  StepperContext: React.Context<Stepper<Steps> | null>,
 ) {
-	return function Item(props: ItemProps<Steps>) {
-		const { step, render, children, ...rest } = props;
-		const stepper = React.useContext(StepperContext);
-		if (!stepper) {
-			throw new Error("Stepper.Item must be used within Stepper.Root.");
-		}
-		const stepIndex = stepper.lookup.getIndex(step);
-		const currentIndex = stepper.state.current.index;
-		const status: StepStatus =
-			stepIndex < currentIndex ? "success" : stepIndex === currentIndex ? "active" : "inactive";
-		const stepData = stepper.lookup.get(step as Get.Id<Steps>);
-		const itemValue = React.useMemo(
-			(): StepItemValue<Get.StepById<Steps, Get.Id<Steps>>> => ({
-				data: stepData,
-				index: stepIndex,
-				status,
-				metadata: {
-					get: () => stepper.metadata.get(step as Get.Id<Steps>),
-					set: <M extends Metadata>(values: M) =>
-						stepper.metadata.set(step as Get.Id<Steps>, values),
-					reset: (keepInitialMetadata?: boolean) =>
-						stepper.metadata.reset(keepInitialMetadata),
-				},
-			}),
-			[step, stepData, stepIndex, status, stepper],
-		);
-		const domProps = {
-			"data-component": "stepper-item",
-			"data-status": status,
-			...rest,
-		};
-		if (render) {
-			return React.createElement(StepItemProvider, {
-				value: itemValue,
-				children: render(domProps)
-			});
-		}
-		return React.createElement(
-			StepItemProvider,
-			{ value: itemValue, children: React.createElement("li", domProps, children) },
-		);
-	};
+  return function Item(props: ItemProps<Steps>) {
+    const { step, render, children, ...rest } = props;
+    const stepper = React.useContext(StepperContext);
+    if (!stepper) {
+      throw new Error("Stepper.Item must be used within Stepper.Root.");
+    }
+    const stepIndex = stepper.lookup.getIndex(step);
+    const currentIndex = stepper.state.current.index;
+    const status: StepStatus =
+      stepIndex < currentIndex
+        ? "success"
+        : stepIndex === currentIndex
+          ? "active"
+          : "inactive";
+    const stepData = stepper.lookup.get(step as Get.Id<Steps>);
+    const itemValue = React.useMemo(
+      (): StepItemValue<Get.StepById<Steps, Get.Id<Steps>>> => ({
+        data: stepData,
+        index: stepIndex,
+        status,
+        metadata: {
+          get: () => stepper.metadata.get(step as Get.Id<Steps>),
+          set: <M extends Metadata>(values: M) =>
+            stepper.metadata.set(step as Get.Id<Steps>, values),
+          reset: (keepInitialMetadata?: boolean) =>
+            stepper.metadata.reset(keepInitialMetadata),
+        },
+      }),
+      [step, stepData, stepIndex, status, stepper],
+    );
+    const domProps = {
+      "data-component": "stepper-item",
+      "data-status": status,
+      ...rest,
+    };
+    if (render) {
+      <StepItemProvider value={itemValue}>{render(domProps)}</StepItemProvider>;
+    }
+    return (
+      <StepItemProvider value={itemValue}>
+        <li {...domProps}>{children}</li>
+      </StepItemProvider>
+    );
+  };
 }

--- a/packages/react/src/primitives/list.tsx
+++ b/packages/react/src/primitives/list.tsx
@@ -1,69 +1,84 @@
-import * as React from "react";
 import type { Step, Stepper } from "@stepperize/core";
+import React from "react";
 import type { ListProps } from "./types";
 
-const ARROW_KEYS = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"] as const;
+const ARROW_KEYS = [
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+] as const;
 
 export function createList<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
+  StepperContext: React.Context<Stepper<Steps> | null>,
 ) {
-	return function List(props: ListProps) {
-		const { orientation = "horizontal", render, children, onKeyDown, ...rest } = props;
-		const stepper = React.useContext(StepperContext);
+  return function List(props: ListProps) {
+    const {
+      orientation = "horizontal",
+      render,
+      children,
+      onKeyDown,
+      ...rest
+    } = props;
+    const stepper = React.useContext(StepperContext);
 
-		const handleKeyDown = React.useCallback(
-			(e: React.KeyboardEvent<HTMLOListElement>) => {
-				onKeyDown?.(e);
-				if (!ARROW_KEYS.includes(e.key as (typeof ARROW_KEYS)[number])) return;
-				const target = e.target as HTMLElement;
-				if (target.getAttribute?.("role") !== "tab") return;
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLOListElement>) => {
+        onKeyDown?.(e);
+        if (!ARROW_KEYS.includes(e.key as (typeof ARROW_KEYS)[number])) return;
+        const target = e.target as HTMLElement;
+        if (target.getAttribute?.("role") !== "tab") return;
 
-				const steps = stepper?.state.all;
-				if (!stepper || !steps?.length) return;
+        const steps = stepper?.state.all;
+        if (!stepper || !steps?.length) return;
 
-				const currentIndex = stepper.state.current.index;
-				const isHorizontal = orientation === "horizontal";
-				const isNext =
-					(isHorizontal && e.key === "ArrowRight") ||
-					(!isHorizontal && e.key === "ArrowDown");
-				const isPrev =
-					(isHorizontal && e.key === "ArrowLeft") ||
-					(!isHorizontal && e.key === "ArrowUp");
-				const isHome = e.key === "Home";
-				const isEnd = e.key === "End";
+        const currentIndex = stepper.state.current.index;
+        const isHorizontal = orientation === "horizontal";
+        const isNext =
+          (isHorizontal && e.key === "ArrowRight") ||
+          (!isHorizontal && e.key === "ArrowDown");
+        const isPrev =
+          (isHorizontal && e.key === "ArrowLeft") ||
+          (!isHorizontal && e.key === "ArrowUp");
+        const isHome = e.key === "Home";
+        const isEnd = e.key === "End";
 
-				if (!isNext && !isPrev && !isHome && !isEnd) return;
+        if (!isNext && !isPrev && !isHome && !isEnd) return;
 
-				e.preventDefault();
+        e.preventDefault();
 
-				let nextIndex: number;
-				if (isHome) nextIndex = 0;
-				else if (isEnd) nextIndex = steps.length - 1;
-				else if (isNext)
-					nextIndex = Math.min(currentIndex + 1, steps.length - 1);
-				else nextIndex = Math.max(currentIndex - 1, 0);
+        let nextIndex: number;
+        if (isHome) nextIndex = 0;
+        else if (isEnd) nextIndex = steps.length - 1;
+        else if (isNext)
+          nextIndex = Math.min(currentIndex + 1, steps.length - 1);
+        else nextIndex = Math.max(currentIndex - 1, 0);
 
-				if (nextIndex === currentIndex) return;
+        if (nextIndex === currentIndex) return;
 
-				const targetStep = steps[nextIndex];
-				stepper.navigation.goTo(targetStep.id as import("@stepperize/core").Get.Id<Steps>);
+        const targetStep = steps[nextIndex];
+        stepper.navigation.goTo(
+          targetStep.id as import("@stepperize/core").Get.Id<Steps>,
+        );
 
-				const targetId = `step-${targetStep.id}`;
-				queueMicrotask(() => document.getElementById(targetId)?.focus());
-			},
-			[stepper, orientation, onKeyDown],
-		);
+        const targetId = `step-${targetStep.id}`;
+        queueMicrotask(() => document.getElementById(targetId)?.focus());
+      },
+      [stepper, orientation, onKeyDown],
+    );
 
-		const domProps = {
-			"data-component": "stepper-list",
-			"data-orientation": orientation,
-			role: "tablist" as const,
-			"aria-orientation": orientation,
-			...rest,
-			onKeyDown: handleKeyDown,
-		};
+    const domProps = {
+      "data-component": "stepper-list",
+      "data-orientation": orientation,
+      role: "tablist" as const,
+      "aria-orientation": orientation,
+      ...rest,
+      onKeyDown: handleKeyDown,
+    };
 
-		if (render) return render(domProps);
-		return React.createElement("ol", domProps, children);
-	};
+    if (render) return render(domProps);
+    return <ol {...domProps}>{children}</ol>;
+  };
 }

--- a/packages/react/src/primitives/list.tsx
+++ b/packages/react/src/primitives/list.tsx
@@ -27,6 +27,7 @@ export function createList<Steps extends Step[]>(
     const handleKeyDown = React.useCallback(
       (e: React.KeyboardEvent<HTMLOListElement>) => {
         onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         if (!ARROW_KEYS.includes(e.key as (typeof ARROW_KEYS)[number])) return;
         const target = e.target as HTMLElement;
         if (target.getAttribute?.("role") !== "tab") return;

--- a/packages/react/src/primitives/next.tsx
+++ b/packages/react/src/primitives/next.tsx
@@ -1,28 +1,28 @@
-import * as React from "react";
 import type { Step, Stepper } from "@stepperize/core";
+import React from "react";
 import type { NextProps } from "./types";
 
 export function createNext<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
+  StepperContext: React.Context<Stepper<Steps> | null>,
 ) {
-	return function Next(props: NextProps) {
-		const { render, children, ...rest } = props;
-		const stepper = React.useContext(StepperContext);
-		if (!stepper) {
-			throw new Error("Stepper.Next must be used within Stepper.Root.");
-		}
-		const domProps = {
-			"data-component": "stepper-next",
-			type: "button" as const,
-			disabled: stepper.state.isLast,
-			"aria-disabled": stepper.state.isLast,
-			onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-				stepper.navigation.next();
-				rest.onClick?.(e);
-			},
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("button", domProps, children);
-	};
+  return function Next(props: NextProps) {
+    const { render, children, ...rest } = props;
+    const stepper = React.useContext(StepperContext);
+    if (!stepper) {
+      throw new Error("Stepper.Next must be used within Stepper.Root.");
+    }
+    const domProps = {
+      "data-component": "stepper-next",
+      type: "button" as const,
+      disabled: stepper.state.isLast,
+      "aria-disabled": stepper.state.isLast,
+      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        stepper.navigation.next();
+        rest.onClick?.(e);
+      },
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <button {...domProps}>{children}</button>;
+  };
 }

--- a/packages/react/src/primitives/next.tsx
+++ b/packages/react/src/primitives/next.tsx
@@ -1,5 +1,6 @@
 import type { Step, Stepper } from "@stepperize/core";
-import React from "react";
+import type React from "react";
+import { runClickHandler, useStepperContextOrThrow } from "./helpers";
 import type { NextProps } from "./types";
 
 export function createNext<Steps extends Step[]>(
@@ -7,19 +8,14 @@ export function createNext<Steps extends Step[]>(
 ) {
   return function Next(props: NextProps) {
     const { render, children, ...rest } = props;
-    const stepper = React.useContext(StepperContext);
-    if (!stepper) {
-      throw new Error("Stepper.Next must be used within Stepper.Root.");
-    }
+    const stepper = useStepperContextOrThrow(StepperContext);
     const domProps = {
       "data-component": "stepper-next",
       type: "button" as const,
       disabled: stepper.state.isLast,
       "aria-disabled": stepper.state.isLast,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        rest.onClick?.(e);
-        if (e.defaultPrevented) return;
-        stepper.navigation.next();
+        runClickHandler(e, rest.onClick, () => stepper.navigation.next());
       },
       ...rest,
     };

--- a/packages/react/src/primitives/next.tsx
+++ b/packages/react/src/primitives/next.tsx
@@ -17,8 +17,9 @@ export function createNext<Steps extends Step[]>(
       disabled: stepper.state.isLast,
       "aria-disabled": stepper.state.isLast,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        stepper.navigation.next();
         rest.onClick?.(e);
+        if (e.defaultPrevented) return;
+        stepper.navigation.next();
       },
       ...rest,
     };

--- a/packages/react/src/primitives/prev.tsx
+++ b/packages/react/src/primitives/prev.tsx
@@ -1,28 +1,28 @@
-import * as React from "react";
 import type { Step, Stepper } from "@stepperize/core";
+import React from "react";
 import type { PrevProps } from "./types";
 
 export function createPrev<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
+  StepperContext: React.Context<Stepper<Steps> | null>,
 ) {
-	return function Prev(props: PrevProps) {
-		const { render, children, ...rest } = props;
-		const stepper = React.useContext(StepperContext);
-		if (!stepper) {
-			throw new Error("Stepper.Prev must be used within Stepper.Root.");
-		}
-		const domProps = {
-			"data-component": "stepper-prev",
-			type: "button" as const,
-			disabled: stepper.state.isFirst,
-			"aria-disabled": stepper.state.isFirst,
-			onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-				stepper.navigation.prev();
-				rest.onClick?.(e);
-			},
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("button", domProps, children);
-	};
+  return function Prev(props: PrevProps) {
+    const { render, children, ...rest } = props;
+    const stepper = React.useContext(StepperContext);
+    if (!stepper) {
+      throw new Error("Stepper.Prev must be used within Stepper.Root.");
+    }
+    const domProps = {
+      "data-component": "stepper-prev",
+      type: "button" as const,
+      disabled: stepper.state.isFirst,
+      "aria-disabled": stepper.state.isFirst,
+      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        stepper.navigation.prev();
+        rest.onClick?.(e);
+      },
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <button {...domProps}>{children}</button>;
+  };
 }

--- a/packages/react/src/primitives/prev.tsx
+++ b/packages/react/src/primitives/prev.tsx
@@ -1,5 +1,6 @@
 import type { Step, Stepper } from "@stepperize/core";
-import React from "react";
+import type React from "react";
+import { runClickHandler, useStepperContextOrThrow } from "./helpers";
 import type { PrevProps } from "./types";
 
 export function createPrev<Steps extends Step[]>(
@@ -7,19 +8,14 @@ export function createPrev<Steps extends Step[]>(
 ) {
   return function Prev(props: PrevProps) {
     const { render, children, ...rest } = props;
-    const stepper = React.useContext(StepperContext);
-    if (!stepper) {
-      throw new Error("Stepper.Prev must be used within Stepper.Root.");
-    }
+    const stepper = useStepperContextOrThrow(StepperContext);
     const domProps = {
       "data-component": "stepper-prev",
       type: "button" as const,
       disabled: stepper.state.isFirst,
       "aria-disabled": stepper.state.isFirst,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        rest.onClick?.(e);
-        if (e.defaultPrevented) return;
-        stepper.navigation.prev();
+        runClickHandler(e, rest.onClick, () => stepper.navigation.prev());
       },
       ...rest,
     };

--- a/packages/react/src/primitives/prev.tsx
+++ b/packages/react/src/primitives/prev.tsx
@@ -17,8 +17,9 @@ export function createPrev<Steps extends Step[]>(
       disabled: stepper.state.isFirst,
       "aria-disabled": stepper.state.isFirst,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        stepper.navigation.prev();
         rest.onClick?.(e);
+        if (e.defaultPrevented) return;
+        stepper.navigation.prev();
       },
       ...rest,
     };

--- a/packages/react/src/primitives/root.tsx
+++ b/packages/react/src/primitives/root.tsx
@@ -18,7 +18,7 @@ export function createRoot<Steps extends Step[]>(
   }: Omit<RootProps<Steps>, "initialStep" | "initialMetadata">) {
     const stepper = React.useContext(StepperContext);
     if (!stepper) {
-      throw new Error("Stepper.Root must be used within Scoped.");
+      throw new Error("Missing Scoped.");
     }
     return React.createElement(
       "div",

--- a/packages/react/src/primitives/root.tsx
+++ b/packages/react/src/primitives/root.tsx
@@ -1,50 +1,54 @@
-import * as React from "react";
 import type { Step, Stepper } from "@stepperize/core";
+import React from "react";
 import type { RootProps } from "./types";
 
 type ScopedProviderProps<Steps extends Step[]> = React.PropsWithChildren<{
-	initialStep?: RootProps<Steps>["initialStep"];
-	initialMetadata?: RootProps<Steps>["initialMetadata"];
+  initialStep?: RootProps<Steps>["initialStep"];
+  initialMetadata?: RootProps<Steps>["initialMetadata"];
 }>;
 
 export function createRoot<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
-	ScopedProvider: (props: ScopedProviderProps<Steps>) => React.ReactElement,
+  StepperContext: React.Context<Stepper<Steps> | null>,
+  ScopedProvider: (props: ScopedProviderProps<Steps>) => React.ReactElement,
 ) {
-	function RootInner({
-		children,
-		orientation,
-		...rest
-	}: Omit<RootProps<Steps>, "initialStep" | "initialMetadata">) {
-		const stepper = React.useContext(StepperContext);
-		if (!stepper) {
-			throw new Error("Stepper.Root must be used within Scoped.");
-		}
-		return React.createElement(
-			"div",
-			{
-				"data-component": "stepper",
-				"data-orientation": orientation,
-				role: "group",
-				"aria-label": "Stepper",
-				...rest,
-			},
-			typeof children === "function" ? children({ stepper }) : children,
-		);
-	}
+  function RootInner({
+    children,
+    orientation,
+    ...rest
+  }: Omit<RootProps<Steps>, "initialStep" | "initialMetadata">) {
+    const stepper = React.useContext(StepperContext);
+    if (!stepper) {
+      throw new Error("Stepper.Root must be used within Scoped.");
+    }
+    return React.createElement(
+      "div",
+      {
+        "data-component": "stepper",
+        "data-orientation": orientation,
+        role: "group",
+        "aria-label": "Stepper",
+        ...rest,
+      },
+      typeof children === "function" ? children({ stepper }) : children,
+    );
+  }
 
-	return function Root(props: RootProps<Steps>) {
-		const { initialStep, initialMetadata, children, ...rootInnerProps } = props;
-		return React.createElement(
-			ScopedProvider,
-			{
-				initialStep,
-				initialMetadata,
-				children: React.createElement(RootInner, {
-					...rootInnerProps,
-					children,
-				} as Omit<RootProps<Steps>, "initialStep" | "initialMetadata">),
-			},
-		);
-	};
+  return function Root(props: RootProps<Steps>) {
+    const { initialStep, initialMetadata, children, ...rootInnerProps } = props;
+    return (
+      <ScopedProvider
+        initialStep={initialStep}
+        initialMetadata={initialMetadata}
+      >
+        <RootInner
+          {...(rootInnerProps as Omit<
+            RootProps<Steps>,
+            "initialStep" | "initialMetadata"
+          >)}
+        >
+          {children}
+        </RootInner>
+      </ScopedProvider>
+    );
+  };
 }

--- a/packages/react/src/primitives/separator.tsx
+++ b/packages/react/src/primitives/separator.tsx
@@ -1,18 +1,23 @@
-import * as React from "react";
 import type { SeparatorProps } from "./types";
 
 export function createSeparator() {
-	return function Separator(props: SeparatorProps) {
-		const { orientation, "data-status": dataStatus, render, children, ...rest } = props;
-		const domProps = {
-			"data-component": "stepper-separator",
-			"data-orientation": orientation,
-			"data-status": dataStatus,
-			"aria-hidden": true,
-			tabIndex: -1,
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("hr", domProps, children);
-	};
+  return function Separator(props: SeparatorProps) {
+    const {
+      orientation,
+      "data-status": dataStatus,
+      render,
+      children,
+      ...rest
+    } = props;
+    const domProps = {
+      "data-component": "stepper-separator",
+      "data-orientation": orientation,
+      "data-status": dataStatus,
+      "aria-hidden": true,
+      tabIndex: -1,
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <hr {...domProps} />;
+  };
 }

--- a/packages/react/src/primitives/title.tsx
+++ b/packages/react/src/primitives/title.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
 import type { TitleProps } from "./types";
 
 export function createTitle() {
-	return function Title(props: TitleProps) {
-		const { render, children, ...rest } = props;
-		const domProps = {
-			"data-component": "stepper-title",
-			...rest,
-		};
-		if (render) return render(domProps)
-		return React.createElement("h4", domProps, children);
-	};
+  return function Title(props: TitleProps) {
+    const { render, children, ...rest } = props;
+    const domProps = {
+      "data-component": "stepper-title",
+      ...rest,
+    };
+    if (render) return render(domProps);
+    return <h4 {...domProps}>{children}</h4>;
+  };
 }

--- a/packages/react/src/primitives/trigger.tsx
+++ b/packages/react/src/primitives/trigger.tsx
@@ -15,7 +15,6 @@ export function createTrigger<Steps extends Step[]>(
     }
     const stepId = item.data.id;
     const isActive = stepper.state.current.data.id === stepId;
-    const stepIndex = stepper.state.all.findIndex((s) => s.id === stepId);
     const handleClick = () =>
       stepper.navigation.goTo(
         stepId as import("@stepperize/core").Get.Id<Steps>,
@@ -29,12 +28,13 @@ export function createTrigger<Steps extends Step[]>(
       tabIndex: item.status === "inactive" ? -1 : 0,
       "aria-controls": `step-panel-${stepId}`,
       "aria-current": isActive ? ("step" as const) : undefined,
-      "aria-posinset": stepIndex + 1,
+      "aria-posinset": item.index + 1,
       "aria-setsize": stepper.state.all.length,
       "aria-selected": isActive,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        handleClick();
         rest.onClick?.(e);
+        if (e.defaultPrevented) return;
+        handleClick();
       },
     };
     if (render) {

--- a/packages/react/src/primitives/trigger.tsx
+++ b/packages/react/src/primitives/trigger.tsx
@@ -1,6 +1,7 @@
 import type { Step, Stepper } from "@stepperize/core";
 import React from "react";
 import { useStepItemContext } from "./context";
+import { runClickHandler, useStepperContextOrThrow } from "./helpers";
 import type { TriggerProps } from "./types";
 
 export function createTrigger<Steps extends Step[]>(
@@ -8,11 +9,8 @@ export function createTrigger<Steps extends Step[]>(
 ) {
   return function Trigger(props: TriggerProps) {
     const { render, children, ...rest } = props;
-    const stepper = React.useContext(StepperContext);
+    const stepper = useStepperContextOrThrow(StepperContext);
     const item = useStepItemContext();
-    if (!stepper) {
-      throw new Error("Stepper.Trigger must be used within Stepper.Root.");
-    }
     const stepId = item.data.id;
     const isActive = stepper.state.current.data.id === stepId;
     const handleClick = () =>
@@ -32,9 +30,7 @@ export function createTrigger<Steps extends Step[]>(
       "aria-setsize": stepper.state.all.length,
       "aria-selected": isActive,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        rest.onClick?.(e);
-        if (e.defaultPrevented) return;
-        handleClick();
+        runClickHandler(e, rest.onClick, handleClick);
       },
     };
     if (render) {

--- a/packages/react/src/primitives/trigger.tsx
+++ b/packages/react/src/primitives/trigger.tsx
@@ -1,5 +1,5 @@
 import type { Step, Stepper } from "@stepperize/core";
-import React from "react";
+import type React from "react";
 import { useStepItemContext } from "./context";
 import { runClickHandler, useStepperContextOrThrow } from "./helpers";
 import type { TriggerProps } from "./types";

--- a/packages/react/src/primitives/trigger.tsx
+++ b/packages/react/src/primitives/trigger.tsx
@@ -1,42 +1,45 @@
-import * as React from "react";
 import type { Step, Stepper } from "@stepperize/core";
-import type { TriggerProps } from "./types";
+import React from "react";
 import { useStepItemContext } from "./context";
+import type { TriggerProps } from "./types";
 
 export function createTrigger<Steps extends Step[]>(
-	StepperContext: React.Context<Stepper<Steps> | null>,
+  StepperContext: React.Context<Stepper<Steps> | null>,
 ) {
-	return function Trigger(props: TriggerProps) {
-		const { render, children, ...rest } = props;
-		const stepper = React.useContext(StepperContext);
-		const item = useStepItemContext();
-		if (!stepper) {
-			throw new Error("Stepper.Trigger must be used within Stepper.Root.");
-		}
-		const stepId = item.data.id;
-		const isActive = stepper.state.current.data.id === stepId;
-		const stepIndex = stepper.state.all.findIndex((s) => s.id === stepId);
-		const handleClick = () => stepper.navigation.goTo(stepId as import("@stepperize/core").Get.Id<Steps>);
-		const domProps = {
-			...rest,
-			id: `step-${stepId}`,
-			"data-component": "stepper-trigger",
-			"data-status": item.status,
-			role: "tab" as const,
-			tabIndex: item.status === "inactive" ? -1 : 0,
-			"aria-controls": `step-panel-${stepId}`,
-			"aria-current": isActive ? ("step" as const) : undefined,
-			"aria-posinset": stepIndex + 1,
-			"aria-setsize": stepper.state.all.length,
-			"aria-selected": isActive ? true : false,
-			onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-				handleClick();
-				rest.onClick?.(e);
-			},
-		};
-		if (render) {
-			return render(domProps);
-		}
-		return React.createElement("button", { type: "button", ...domProps }, children);
-	};
+  return function Trigger(props: TriggerProps) {
+    const { render, children, ...rest } = props;
+    const stepper = React.useContext(StepperContext);
+    const item = useStepItemContext();
+    if (!stepper) {
+      throw new Error("Stepper.Trigger must be used within Stepper.Root.");
+    }
+    const stepId = item.data.id;
+    const isActive = stepper.state.current.data.id === stepId;
+    const stepIndex = stepper.state.all.findIndex((s) => s.id === stepId);
+    const handleClick = () =>
+      stepper.navigation.goTo(
+        stepId as import("@stepperize/core").Get.Id<Steps>,
+      );
+    const domProps = {
+      ...rest,
+      id: `step-${stepId}`,
+      "data-component": "stepper-trigger",
+      "data-status": item.status,
+      role: "tab" as const,
+      tabIndex: item.status === "inactive" ? -1 : 0,
+      "aria-controls": `step-panel-${stepId}`,
+      "aria-current": isActive ? ("step" as const) : undefined,
+      "aria-posinset": stepIndex + 1,
+      "aria-setsize": stepper.state.all.length,
+      "aria-selected": isActive,
+      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        handleClick();
+        rest.onClick?.(e);
+      },
+    };
+    if (render) {
+      return render(domProps);
+    }
+    return <button {...domProps}>{children}</button>;
+  };
 }

--- a/packages/react/src/primitives/types.ts
+++ b/packages/react/src/primitives/types.ts
@@ -1,51 +1,59 @@
-import type { Get, Metadata, Step, Stepper, StepStatus } from "@stepperize/core";
-import * as React from "react";
+import type {
+  Get,
+  Metadata,
+  Step,
+  Stepper,
+  StepStatus,
+} from "@stepperize/core";
+import type * as React from "react";
 
 export type { StepStatus };
 
 export type StepInfo<S extends Step = Step> = {
-	data: S;
-	status: StepStatus;
+  data: S;
+  status: StepStatus;
 };
 
 /** Render function receiving DOM props. */
 export type RenderProp<E extends React.ElementType = "div"> = (
-	props: React.ComponentPropsWithoutRef<E>,
+  props: React.ComponentPropsWithoutRef<E>,
 ) => React.ReactNode;
 
 export type PrimitiveProps<E extends React.ElementType = "div"> = Omit<
-	React.ComponentPropsWithoutRef<E>,
-	"children"
+  React.ComponentPropsWithoutRef<E>,
+  "children"
 > & {
-	/**
-	 * Custom render function for complete control over the rendered element.
-	 * Receives all props including data attributes, event handlers, and ARIA attributes.
-	 */
-	render?: RenderProp<E>;
-	/**
-	 * Children can be a ReactNode or a function receiving step info.
-	 */
-	children?: React.ReactNode;
+  /**
+   * Custom render function for complete control over the rendered element.
+   * Receives all props including data attributes, event handlers, and ARIA attributes.
+   */
+  render?: RenderProp<E>;
+  /**
+   * Children can be a ReactNode or a function receiving step info.
+   */
+  children?: React.ReactNode;
 };
 
 export type RootProps<Steps extends Step[]> = Omit<
-	React.ComponentPropsWithoutRef<"div">,
-	"children"
+  React.ComponentPropsWithoutRef<"div">,
+  "children"
 > & {
-	orientation?: "horizontal" | "vertical";
-	/** Initial step (passed to Scoped internally). */
-	initialStep?: Get.Id<Steps>;
-	/** Initial metadata (passed to Scoped internally). */
-	initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
-	children: React.ReactNode | ((props: { stepper: Stepper<Steps> }) => React.ReactNode);
+  orientation?: "horizontal" | "vertical";
+  /** Initial step (passed to Scoped internally). */
+  initialStep?: Get.Id<Steps>;
+  /** Initial metadata (passed to Scoped internally). */
+  initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+  children:
+    | React.ReactNode
+    | ((props: { stepper: Stepper<Steps> }) => React.ReactNode);
 };
 
 export type ListProps = PrimitiveProps<"ol"> & {
-	orientation?: "horizontal" | "vertical";
+  orientation?: "horizontal" | "vertical";
 };
 
 export type ItemProps<Steps extends Step[]> = PrimitiveProps<"li"> & {
-	step: Get.Id<Steps>;
+  step: Get.Id<Steps>;
 };
 
 export type TriggerProps = PrimitiveProps<"button">;
@@ -55,12 +63,12 @@ export type DescriptionProps = PrimitiveProps<"p">;
 export type IndicatorProps = PrimitiveProps<"span">;
 
 export type SeparatorProps = PrimitiveProps<"hr"> & {
-	orientation?: "horizontal" | "vertical";
-	"data-status"?: StepStatus;
+  orientation?: "horizontal" | "vertical";
+  "data-status"?: StepStatus;
 };
 
 export type ContentProps<Steps extends Step[]> = PrimitiveProps<"div"> & {
-	step: Get.Id<Steps>;
+  step: Get.Id<Steps>;
 };
 
 export type ActionsProps = PrimitiveProps<"div">;

--- a/packages/react/src/tests/define-stepper.test.tsx
+++ b/packages/react/src/tests/define-stepper.test.tsx
@@ -1,361 +1,538 @@
 import { act, render, renderHook, screen } from "@testing-library/react";
-import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { defineStepper } from "../define-stepper";
 
 const steps = [
-	{ id: "first", title: "First" },
-	{ id: "second", title: "Second" },
-	{ id: "third", title: "Third" },
+  { id: "first", title: "First" },
+  { id: "second", title: "Second" },
+  { id: "third", title: "Third" },
 ] as const;
 
 describe("defineStepper", () => {
-	it("returns steps, Scoped, useStepper, Stepper", () => {
-		const result = defineStepper(...steps);
-		expect(result.steps).toEqual(steps);
-		expect(result.Scoped).toBeDefined();
-		expect(typeof result.useStepper).toBe("function");
-		expect(result.Stepper).toBeDefined();
-		expect(result.Stepper.Root).toBeDefined();
-		expect(result.Stepper.List).toBeDefined();
-		expect(result.Stepper.Item).toBeDefined();
-		expect(result.Stepper.Trigger).toBeDefined();
-		expect(result.Stepper.Content).toBeDefined();
-		expect(result.Stepper.Prev).toBeDefined();
-		expect(result.Stepper.Next).toBeDefined();
-	});
+  it("returns steps, Scoped, useStepper, Stepper", () => {
+    const result = defineStepper(...steps);
+    expect(result.steps).toEqual(steps);
+    expect(result.Scoped).toBeDefined();
+    expect(typeof result.useStepper).toBe("function");
+    expect(result.Stepper).toBeDefined();
+    expect(result.Stepper.Root).toBeDefined();
+    expect(result.Stepper.List).toBeDefined();
+    expect(result.Stepper.Item).toBeDefined();
+    expect(result.Stepper.Trigger).toBeDefined();
+    expect(result.Stepper.Content).toBeDefined();
+    expect(result.Stepper.Prev).toBeDefined();
+    expect(result.Stepper.Next).toBeDefined();
+  });
 
-	it("useStepper returns stepper with state, navigation, lookup, flow, metadata, lifecycle", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const stepper = result.current;
-		expect(stepper.state.all).toEqual(steps);
-		expect(stepper.state.current.data).toEqual(steps[0]);
-		expect(stepper.state.current.index).toBe(0);
-		expect(stepper.state.current.status).toBe("active");
-		expect(stepper.state.isFirst).toBe(true);
-		expect(stepper.state.isLast).toBe(false);
-		expect(stepper.navigation.next).toBeDefined();
-		expect(stepper.navigation.prev).toBeDefined();
-		expect(stepper.navigation.goTo).toBeDefined();
-		expect(stepper.navigation.reset).toBeDefined();
-		expect(stepper.lookup.get("second")).toEqual(steps[1]);
-		expect(typeof stepper.flow.is).toBe("function");
-		expect(stepper.flow.is("first")).toBe(true);
-		expect(stepper.flow.is("second")).toBe(false);
-		expect(stepper.metadata.get("first")).toBeNull();
-		expect(stepper.lifecycle.onBeforeTransition).toBeDefined();
-		expect(stepper.lifecycle.onAfterTransition).toBeDefined();
-	});
+  it("useStepper returns stepper with state, navigation, lookup, flow, metadata, lifecycle", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const stepper = result.current;
+    expect(stepper.state.all).toEqual(steps);
+    expect(stepper.state.current.data).toEqual(steps[0]);
+    expect(stepper.state.current.index).toBe(0);
+    expect(stepper.state.current.status).toBe("active");
+    expect(stepper.state.isFirst).toBe(true);
+    expect(stepper.state.isLast).toBe(false);
+    expect(stepper.navigation.next).toBeDefined();
+    expect(stepper.navigation.prev).toBeDefined();
+    expect(stepper.navigation.goTo).toBeDefined();
+    expect(stepper.navigation.reset).toBeDefined();
+    expect(stepper.lookup.get("second")).toEqual(steps[1]);
+    expect(typeof stepper.flow.is).toBe("function");
+    expect(stepper.flow.is("first")).toBe(true);
+    expect(stepper.flow.is("second")).toBe(false);
+    expect(stepper.metadata.get("first")).toBeNull();
+    expect(stepper.lifecycle.onBeforeTransition).toBeDefined();
+    expect(stepper.lifecycle.onAfterTransition).toBeDefined();
+  });
 
-	it("useStepper with initialStep starts at that step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper({ initialStep: "third" }));
-		expect(result.current.state.current.data.id).toBe("third");
-		expect(result.current.state.current.index).toBe(2);
-		expect(result.current.state.isLast).toBe(true);
-	});
+  it("useStepper with initialStep starts at that step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper({ initialStep: "third" }));
+    expect(result.current.state.current.data.id).toBe("third");
+    expect(result.current.state.current.index).toBe(2);
+    expect(result.current.state.isLast).toBe(true);
+  });
 
-	it("useStepper with initialMetadata seeds metadata per step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() =>
-			useStepper({ initialMetadata: { first: { saved: true }, second: { count: 2 } } }),
-		);
-		expect(result.current.metadata.get("first")).toEqual({ saved: true });
-		expect(result.current.metadata.get("second")).toEqual({ count: 2 });
-		expect(result.current.metadata.get("third")).toBeNull();
-	});
+  it("useStepper with initialMetadata seeds metadata per step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() =>
+      useStepper({
+        initialMetadata: { first: { saved: true }, second: { count: 2 } },
+      }),
+    );
+    expect(result.current.metadata.get("first")).toEqual({ saved: true });
+    expect(result.current.metadata.get("second")).toEqual({ count: 2 });
+    expect(result.current.metadata.get("third")).toBeNull();
+  });
 
-	it("navigation.next advances step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		expect(result.current.state.current.data.id).toBe("first");
-		act(() => {
-			result.current.navigation.next();
-		});
-		expect(result.current.state.current.data.id).toBe("second");
-		act(() => {
-			result.current.navigation.next();
-		});
-		expect(result.current.state.current.data.id).toBe("third");
-	});
+  it("navigation.next advances step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    expect(result.current.state.current.data.id).toBe("first");
+    act(() => {
+      result.current.navigation.next();
+    });
+    expect(result.current.state.current.data.id).toBe("second");
+    act(() => {
+      result.current.navigation.next();
+    });
+    expect(result.current.state.current.data.id).toBe("third");
+  });
 
-	it("navigation.prev goes back", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper({ initialStep: "third" }));
-		act(() => {
-			result.current.navigation.prev();
-		});
-		expect(result.current.state.current.data.id).toBe("second");
-		act(() => {
-			result.current.navigation.prev();
-		});
-		expect(result.current.state.current.data.id).toBe("first");
-	});
+  it("navigation.prev goes back", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper({ initialStep: "third" }));
+    act(() => {
+      result.current.navigation.prev();
+    });
+    expect(result.current.state.current.data.id).toBe("second");
+    act(() => {
+      result.current.navigation.prev();
+    });
+    expect(result.current.state.current.data.id).toBe("first");
+  });
 
-	it("navigation.goTo jumps to step by id", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		act(() => {
-			result.current.navigation.goTo("third");
-		});
-		expect(result.current.state.current.data.id).toBe("third");
-		act(() => {
-			result.current.navigation.goTo("first");
-		});
-		expect(result.current.state.current.data.id).toBe("first");
-	});
+  it("navigation.goTo jumps to step by id", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    act(() => {
+      result.current.navigation.goTo("third");
+    });
+    expect(result.current.state.current.data.id).toBe("third");
+    act(() => {
+      result.current.navigation.goTo("first");
+    });
+    expect(result.current.state.current.data.id).toBe("first");
+  });
 
-	it("navigation.goTo throws if step id not found", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		expect(() => {
-			act(() => {
-				result.current.navigation.goTo("not-exist" as any);
-			});
-		}).toThrow(/not found/);
-	});
+  it("navigation.goTo throws if step id not found", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    expect(() => {
+      act(() => {
+        result.current.navigation.goTo("not-exist" as any);
+      });
+    }).toThrow(/not found/);
+  });
 
-	it("navigation.reset restores initial step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper({ initialStep: "second" }));
-		act(() => {
-			result.current.navigation.next();
-		});
-		expect(result.current.state.current.data.id).toBe("third");
-		act(() => {
-			result.current.navigation.reset();
-		});
-		expect(result.current.state.current.data.id).toBe("second");
-	});
+  it("navigation.reset restores initial step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper({ initialStep: "second" }));
+    act(() => {
+      result.current.navigation.next();
+    });
+    expect(result.current.state.current.data.id).toBe("third");
+    act(() => {
+      result.current.navigation.reset();
+    });
+    expect(result.current.state.current.data.id).toBe("second");
+  });
 
-	it("flow.switch returns result for current step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const out = result.current.flow.switch({
-			first: (s) => s.title,
-			second: (s) => s.title,
-			third: (s) => s.title,
-		});
-		expect(out).toBe("First");
-		act(() => result.current.navigation.next());
-		const out2 = result.current.flow.switch({
-			first: (s) => s.title,
-			second: (s) => s.title,
-			third: (s) => s.title,
-		});
-		expect(out2).toBe("Second");
-	});
+  it("flow.switch returns result for current step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const out = result.current.flow.switch({
+      first: (s) => s.title,
+      second: (s) => s.title,
+      third: (s) => s.title,
+    });
+    expect(out).toBe("First");
+    act(() => result.current.navigation.next());
+    const out2 = result.current.flow.switch({
+      first: (s) => s.title,
+      second: (s) => s.title,
+      third: (s) => s.title,
+    });
+    expect(out2).toBe("Second");
+  });
 
-	it("metadata.set and get persist per step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		act(() => {
-			result.current.metadata.set("first", { draft: true });
-		});
-		expect(result.current.metadata.get("first")).toEqual({ draft: true });
-		act(() => result.current.navigation.next());
-		expect(result.current.metadata.get("second")).toBeNull();
-		expect(result.current.metadata.get("first")).toEqual({ draft: true });
-	});
+  it("metadata.set and get persist per step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    act(() => {
+      result.current.metadata.set("first", { draft: true });
+    });
+    expect(result.current.metadata.get("first")).toEqual({ draft: true });
+    act(() => result.current.navigation.next());
+    expect(result.current.metadata.get("second")).toBeNull();
+    expect(result.current.metadata.get("first")).toEqual({ draft: true });
+  });
 
-	it("state.current.metadata get/set for current step", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		expect(result.current.state.current.metadata.get()).toBeNull();
-		act(() => {
-			result.current.state.current.metadata.set({ count: 1 });
-		});
-		expect(result.current.state.current.metadata.get()).toEqual({ count: 1 });
-	});
+  it("state.current.metadata get/set for current step", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    expect(result.current.state.current.metadata.get()).toBeNull();
+    act(() => {
+      result.current.state.current.metadata.set({ count: 1 });
+    });
+    expect(result.current.state.current.metadata.get()).toEqual({ count: 1 });
+  });
 
-	it("Scoped provides same stepper to children via useStepper", () => {
-		const { Scoped, useStepper } = defineStepper(...steps);
-		let childStepper: ReturnType<typeof useStepper> | null = null;
-		function Child() {
-			childStepper = useStepper();
-			return <span data-testid="child">{childStepper.state.current.data.id}</span>;
-		}
-		render(
-			<Scoped>
-				<Child />
-			</Scoped>,
-		);
-		expect(childStepper).not.toBeNull();
-		expect(childStepper!.state.current.data.id).toBe("first");
-		expect(screen.getByTestId("child").textContent).toBe("first");
-	});
+  it("Scoped provides same stepper to children via useStepper", () => {
+    const { Scoped, useStepper } = defineStepper(...steps);
+    let childStepper: ReturnType<typeof useStepper> | null = null;
+    function Child() {
+      childStepper = useStepper();
+      return (
+        <span data-testid="child">{childStepper.state.current.data.id}</span>
+      );
+    }
+    render(
+      <Scoped>
+        <Child />
+      </Scoped>,
+    );
+    expect(childStepper).not.toBeNull();
+    expect(childStepper!.state.current.data.id).toBe("first");
+    expect(screen.getByTestId("child").textContent).toBe("first");
+  });
 
-	it("Scoped with initialStep provides that step to children", () => {
-		const { Scoped, useStepper } = defineStepper(...steps);
-		let childStepper: ReturnType<typeof useStepper> | null = null;
-		function Child() {
-			childStepper = useStepper();
-			return <span data-testid="child">{childStepper!.state.current.data.id}</span>;
-		}
-		render(
-			<Scoped initialStep="second">
-				<Child />
-			</Scoped>,
-		);
-		expect(childStepper!.state.current.data.id).toBe("second");
-		expect(screen.getByTestId("child").textContent).toBe("second");
-	});
+  it("Scoped with initialStep provides that step to children", () => {
+    const { Scoped, useStepper } = defineStepper(...steps);
+    let childStepper: ReturnType<typeof useStepper> | null = null;
+    function Child() {
+      childStepper = useStepper();
+      return (
+        <span data-testid="child">{childStepper!.state.current.data.id}</span>
+      );
+    }
+    render(
+      <Scoped initialStep="second">
+        <Child />
+      </Scoped>,
+    );
+    expect(childStepper!.state.current.data.id).toBe("second");
+    expect(screen.getByTestId("child").textContent).toBe("second");
+  });
 
-	it("flow.when returns whenFn when step matches, elseFn otherwise", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		expect(
-			result.current.flow.when(
-				"first",
-				(s) => s.title,
-				() => "else",
-			),
-		).toBe("First");
-		expect(
-			result.current.flow.when(
-				"second",
-				() => "when",
-				() => "else",
-			),
-		).toBe("else");
-		act(() => result.current.navigation.next());
-		expect(
-			result.current.flow.when(
-				"second",
-				(s) => s.title,
-				() => "else",
-			),
-		).toBe("Second");
-	});
+  it("flow.when returns whenFn when step matches, elseFn otherwise", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    expect(
+      result.current.flow.when(
+        "first",
+        (s) => s.title,
+        () => "else",
+      ),
+    ).toBe("First");
+    expect(
+      result.current.flow.when(
+        "second",
+        () => "when",
+        () => "else",
+      ),
+    ).toBe("else");
+    act(() => result.current.navigation.next());
+    expect(
+      result.current.flow.when(
+        "second",
+        (s) => s.title,
+        () => "else",
+      ),
+    ).toBe("Second");
+  });
 
-	it("flow.match returns result for given state id", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const out = result.current.flow.match("second", {
-			first: (s) => s.title,
-			second: (s) => s.title,
-			third: (s) => s.title,
-		});
-		expect(out).toBe("Second");
-		expect(result.current.flow.match("missing" as any, {})).toBeNull();
-	});
+  it("flow.match returns result for given state id", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const out = result.current.flow.match("second", {
+      first: (s) => s.title,
+      second: (s) => s.title,
+      third: (s) => s.title,
+    });
+    expect(out).toBe("Second");
+    expect(result.current.flow.match("missing" as any, {})).toBeNull();
+  });
 
-	it("metadata.reset clears metadata; keepInitialMetadata restores initial", () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() =>
-			useStepper({ initialMetadata: { first: { x: 1 } } }),
-		);
-		act(() => result.current.metadata.set("second", { y: 2 }));
-		expect(result.current.metadata.get("first")).toEqual({ x: 1 });
-		expect(result.current.metadata.get("second")).toEqual({ y: 2 });
-		act(() => result.current.metadata.reset(false));
-		expect(result.current.metadata.get("first")).toBeNull();
-		expect(result.current.metadata.get("second")).toBeNull();
-		act(() => result.current.metadata.set("first", { x: 1 }));
-		act(() => result.current.metadata.set("second", { y: 2 }));
-		act(() => result.current.metadata.reset(true));
-		expect(result.current.metadata.get("first")).toEqual({ x: 1 });
-		expect(result.current.metadata.get("second")).toBeNull();
-	});
+  it("metadata.reset clears metadata; keepInitialMetadata restores initial", () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() =>
+      useStepper({ initialMetadata: { first: { x: 1 } } }),
+    );
+    act(() => result.current.metadata.set("second", { y: 2 }));
+    expect(result.current.metadata.get("first")).toEqual({ x: 1 });
+    expect(result.current.metadata.get("second")).toEqual({ y: 2 });
+    act(() => result.current.metadata.reset(false));
+    expect(result.current.metadata.get("first")).toBeNull();
+    expect(result.current.metadata.get("second")).toBeNull();
+    act(() => result.current.metadata.set("first", { x: 1 }));
+    act(() => result.current.metadata.set("second", { y: 2 }));
+    act(() => result.current.metadata.reset(true));
+    expect(result.current.metadata.get("first")).toEqual({ x: 1 });
+    expect(result.current.metadata.get("second")).toBeNull();
+  });
 
-	it("Stepper.Root provides stepper to children render prop", () => {
-		const { Stepper, useStepper } = defineStepper(...steps);
-		type StepperInstance = ReturnType<typeof useStepper>;
-		let receivedStepper: StepperInstance | null = null;
-		render(
-			<Stepper.Root>
-				{({ stepper }) => {
-					receivedStepper = stepper;
-					return <span data-testid="root-child">{stepper.state.current.data.id}</span>;
-				}}
-			</Stepper.Root>,
-		);
-		expect(receivedStepper).not.toBeNull();
-		expect(receivedStepper!.state.current.data.id).toBe("first");
-		expect(screen.getByTestId("root-child").textContent).toBe("first");
-	});
+  it("Stepper.Root provides stepper to children render prop", () => {
+    const { Stepper, useStepper } = defineStepper(...steps);
+    type StepperInstance = ReturnType<typeof useStepper>;
+    let receivedStepper: StepperInstance | null = null;
+    render(
+      <Stepper.Root>
+        {({ stepper }) => {
+          receivedStepper = stepper;
+          return (
+            <span data-testid="root-child">
+              {stepper.state.current.data.id}
+            </span>
+          );
+        }}
+      </Stepper.Root>,
+    );
+    expect(receivedStepper).not.toBeNull();
+    expect(receivedStepper!.state.current.data.id).toBe("first");
+    expect(screen.getByTestId("root-child").textContent).toBe("first");
+  });
 
-	it("onBeforeTransition return false cancels transition", async () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const onBefore = vi.fn().mockResolvedValue(false);
-		act(() => {
-			result.current.lifecycle.onBeforeTransition(onBefore);
-		});
-		await act(async () => {
-			await result.current.navigation.next();
-		});
-		expect(onBefore).toHaveBeenCalled();
-		expect(result.current.state.current.data.id).toBe("first");
-	});
+  it("onBeforeTransition return false cancels transition", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const onBefore = vi.fn().mockResolvedValue(false);
+    act(() => {
+      result.current.lifecycle.onBeforeTransition(onBefore);
+    });
+    await act(async () => {
+      await result.current.navigation.next();
+    });
+    expect(onBefore).toHaveBeenCalled();
+    expect(result.current.state.current.data.id).toBe("first");
+  });
 
-	it("onAfterTransition is called after transition", async () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const onAfter = vi.fn().mockResolvedValue(undefined);
-		act(() => {
-			result.current.lifecycle.onAfterTransition(onAfter);
-		});
-		await act(async () => {
-			result.current.navigation.next();
-		});
-		expect(onAfter).toHaveBeenCalledTimes(1);
-		expect(onAfter.mock.calls[0][0].from.id).toBe("first");
-		expect(onAfter.mock.calls[0][0].to.id).toBe("second");
-		expect(onAfter.mock.calls[0][0].direction).toBe("next");
-	});
+  it("onAfterTransition is called after transition", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const onAfter = vi.fn().mockResolvedValue(undefined);
+    act(() => {
+      result.current.lifecycle.onAfterTransition(onAfter);
+    });
+    await act(async () => {
+      result.current.navigation.next();
+    });
+    expect(onAfter).toHaveBeenCalledTimes(1);
+    expect(onAfter.mock.calls[0][0].from.id).toBe("first");
+    expect(onAfter.mock.calls[0][0].to.id).toBe("second");
+    expect(onAfter.mock.calls[0][0].direction).toBe("next");
+  });
 
-	it("multiple onBeforeTransition callbacks run in order; false cancels", async () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const first = vi.fn().mockResolvedValue(undefined);
-		const second = vi.fn().mockResolvedValue(false);
-		act(() => {
-			result.current.lifecycle.onBeforeTransition(first);
-			result.current.lifecycle.onBeforeTransition(second);
-		});
-		await act(async () => {
-			await result.current.navigation.next();
-		});
-		expect(first).toHaveBeenCalledTimes(1);
-		expect(second).toHaveBeenCalledTimes(1);
-		expect(result.current.state.current.data.id).toBe("first");
-	});
+  it("multiple onBeforeTransition callbacks run in order; false cancels", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const first = vi.fn().mockResolvedValue(undefined);
+    const second = vi.fn().mockResolvedValue(false);
+    act(() => {
+      result.current.lifecycle.onBeforeTransition(first);
+      result.current.lifecycle.onBeforeTransition(second);
+    });
+    await act(async () => {
+      await result.current.navigation.next();
+    });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(result.current.state.current.data.id).toBe("first");
+  });
 
-	it("onBeforeTransition returns unsubscribe", async () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		const onBefore = vi.fn().mockResolvedValue(undefined);
-		let unsubscribe: () => void;
-		act(() => {
-			unsubscribe = result.current.lifecycle.onBeforeTransition(onBefore);
-		});
-		unsubscribe!();
-		await act(async () => {
-			await result.current.navigation.next();
-		});
-		expect(onBefore).not.toHaveBeenCalled();
-		expect(result.current.state.current.data.id).toBe("second");
-	});
+  it("onBeforeTransition returns unsubscribe", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const onBefore = vi.fn().mockResolvedValue(undefined);
+    let unsubscribe: () => void;
+    act(() => {
+      unsubscribe = result.current.lifecycle.onBeforeTransition(onBefore);
+    });
+    unsubscribe!();
+    await act(async () => {
+      await result.current.navigation.next();
+    });
+    expect(onBefore).not.toHaveBeenCalled();
+    expect(result.current.state.current.data.id).toBe("second");
+  });
 
-	it("next(payload) merges metadata into ctx and persists", async () => {
-		const { useStepper } = defineStepper(...steps);
-		const { result } = renderHook(() => useStepper());
-		let seenMetadata: Record<string, unknown> = {};
-		act(() => {
-			result.current.lifecycle.onBeforeTransition((ctx) => {
-				seenMetadata = { ...ctx.metadata };
-			});
-		});
-		await act(async () => {
-			await result.current.navigation.next({
-				metadata: { first: { url: "https://example.com" }, second: { foo: 1 } },
-			});
-		});
-		expect(seenMetadata.first).toEqual({ url: "https://example.com" });
-		expect(seenMetadata.second).toEqual({ foo: 1 });
-		expect(result.current.metadata.get("first")).toEqual({ url: "https://example.com" });
-		expect(result.current.metadata.get("second")).toEqual({ foo: 1 });
-	});
+  it("next(payload) merges metadata into ctx and persists", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    let seenMetadata: Record<string, unknown> = {};
+    act(() => {
+      result.current.lifecycle.onBeforeTransition((ctx) => {
+        seenMetadata = { ...ctx.metadata };
+      });
+    });
+    await act(async () => {
+      await result.current.navigation.next({
+        metadata: { first: { url: "https://example.com" }, second: { foo: 1 } },
+      });
+    });
+    expect(seenMetadata.first).toEqual({ url: "https://example.com" });
+    expect(seenMetadata.second).toEqual({ foo: 1 });
+    expect(result.current.metadata.get("first")).toEqual({
+      url: "https://example.com",
+    });
+    expect(result.current.metadata.get("second")).toEqual({ foo: 1 });
+  });
+
+  it("onBeforeTransition cancel does not call onAfterTransition", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const onBefore = vi.fn().mockResolvedValue(false);
+    const onAfter = vi.fn();
+
+    act(() => {
+      result.current.lifecycle.onBeforeTransition(onBefore);
+      result.current.lifecycle.onAfterTransition(onAfter);
+    });
+
+    await act(async () => {
+      await result.current.navigation.next();
+    });
+
+    expect(onBefore).toHaveBeenCalledTimes(1);
+    expect(onAfter).not.toHaveBeenCalled();
+    expect(result.current.state.current.data.id).toBe("first");
+  });
+
+  it("lifecycle ctx is correct for prev and goTo transitions", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper({ initialStep: "second" }));
+
+    const before = vi.fn();
+    const after = vi.fn();
+
+    act(() => {
+      result.current.lifecycle.onBeforeTransition(before);
+      result.current.lifecycle.onAfterTransition(after);
+    });
+
+    await act(async () => {
+      await result.current.navigation.prev();
+    });
+
+    expect(before).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        direction: "prev",
+        fromIndex: 1,
+        toIndex: 0,
+      }),
+    );
+    expect(before.mock.calls[0]?.[0]?.statuses).toEqual({
+      first: "success",
+      second: "active",
+      third: "inactive",
+    });
+    expect(after).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        direction: "prev",
+        fromIndex: 1,
+        toIndex: 0,
+      }),
+    );
+    expect(after.mock.calls[0]?.[0]?.statuses).toEqual({
+      first: "active",
+      second: "inactive",
+      third: "inactive",
+    });
+
+    await act(async () => {
+      await result.current.navigation.goTo("third");
+    });
+
+    expect(before).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        direction: "goTo",
+        fromIndex: 0,
+        toIndex: 2,
+      }),
+    );
+    expect(after).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        direction: "goTo",
+        fromIndex: 0,
+        toIndex: 2,
+      }),
+    );
+    expect(result.current.state.current.data.id).toBe("third");
+  });
+
+  it("onAfterTransition returns unsubscribe and removes callback", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    const onAfter = vi.fn();
+
+    let unsubscribe: () => void;
+    act(() => {
+      unsubscribe = result.current.lifecycle.onAfterTransition(onAfter);
+    });
+
+    await act(async () => {
+      await result.current.navigation.next();
+    });
+    expect(onAfter).toHaveBeenCalledTimes(1);
+
+    unsubscribe!();
+
+    await act(async () => {
+      await result.current.navigation.prev();
+    });
+    expect(onAfter).toHaveBeenCalledTimes(1);
+  });
+
+  it("isTransitioning is true during async lifecycle callbacks", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+
+    let releaseBefore: (() => void) | undefined;
+    const beforeGate = new Promise<void>((resolve) => {
+      releaseBefore = resolve;
+    });
+
+    act(() => {
+      result.current.lifecycle.onBeforeTransition(async () => {
+        await beforeGate;
+      });
+    });
+
+    act(() => {
+      void result.current.navigation.next();
+    });
+
+    expect(result.current.state.isTransitioning).toBe(true);
+    expect(result.current.state.current.data.id).toBe("first");
+
+    releaseBefore?.();
+
+    await act(async () => {
+      await beforeGate;
+    });
+
+    expect(result.current.state.current.data.id).toBe("second");
+    expect(result.current.state.isTransitioning).toBe(false);
+  });
+
+  it("payload metadata is visible in onBefore ctx but not persisted when transition is canceled", async () => {
+    const { useStepper } = defineStepper(...steps);
+    const { result } = renderHook(() => useStepper());
+    let seenMetadata: Record<string, unknown> = {};
+
+    act(() => {
+      result.current.lifecycle.onBeforeTransition((ctx) => {
+        seenMetadata = { ...ctx.metadata };
+        return false;
+      });
+    });
+
+    await act(async () => {
+      await result.current.navigation.next({
+        metadata: { first: { draft: true }, second: { foo: 1 } },
+      });
+    });
+
+    expect(seenMetadata.first).toEqual({ draft: true });
+    expect(seenMetadata.second).toEqual({ foo: 1 });
+    expect(result.current.metadata.get("first")).toBeNull();
+    expect(result.current.metadata.get("second")).toBeNull();
+    expect(result.current.state.current.data.id).toBe("first");
+  });
 });

--- a/packages/react/src/tests/define-stepper.test.tsx
+++ b/packages/react/src/tests/define-stepper.test.tsx
@@ -117,6 +117,30 @@ describe("defineStepper", () => {
     }).toThrow(/not found/);
   });
 
+  it("navigation boundaries throw even with lifecycle callbacks or payload metadata", () => {
+    const { useStepper } = defineStepper(...steps);
+
+    const first = renderHook(() => useStepper());
+    act(() => {
+      first.result.current.lifecycle.onBeforeTransition(() => {});
+    });
+    expect(() => {
+      act(() => {
+        void first.result.current.navigation.prev();
+      });
+    }).toThrow(/first step/);
+
+    const last = renderHook(() => useStepper({ initialStep: "third" }));
+    act(() => {
+      last.result.current.lifecycle.onAfterTransition(() => {});
+    });
+    expect(() => {
+      act(() => {
+        void last.result.current.navigation.next({ metadata: { third: { x: 1 } } });
+      });
+    }).toThrow(/last step/);
+  });
+
   it("navigation.reset restores initial step", () => {
     const { useStepper } = defineStepper(...steps);
     const { result } = renderHook(() => useStepper({ initialStep: "second" }));

--- a/packages/react/src/tests/primitives.test.tsx
+++ b/packages/react/src/tests/primitives.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { defineStepper } from "../define-stepper";
+import { useStepItemContext } from "../primitives";
+
+const steps = [
+  { id: "first", title: "First" },
+  { id: "second", title: "Second" },
+] as const;
+
+describe("primitives", () => {
+  it("Stepper.Item render prop renders custom node and keeps item context", () => {
+    const { Stepper } = defineStepper(...steps);
+
+    function ItemStatus() {
+      const item = useStepItemContext();
+      return (
+        <span data-testid={`status-${item.data.id}`}>{item.status}</span>
+      );
+    }
+
+    render(
+      <Stepper.Root>
+        {({ stepper }) => (
+          <Stepper.List>
+            {stepper.state.all.map((step) => (
+              <Stepper.Item
+                key={step.id}
+                step={step.id}
+                render={(props) => (
+                  <li {...props} data-testid={`item-${step.id}`}>
+                    <ItemStatus />
+                  </li>
+                )}
+              />
+            ))}
+          </Stepper.List>
+        )}
+      </Stepper.Root>,
+    );
+
+    expect(screen.getByTestId("item-first")).toBeTruthy();
+    expect(screen.getByTestId("item-second")).toBeTruthy();
+    expect(screen.getByTestId("status-first").textContent).toBe("active");
+    expect(screen.getByTestId("status-second").textContent).toBe("inactive");
+  });
+
+  it("Stepper.Trigger respects preventDefault in onClick", () => {
+    const { Stepper } = defineStepper(...steps);
+
+    render(
+      <Stepper.Root>
+        {({ stepper }) => (
+          <>
+            <span data-testid="current">{stepper.state.current.data.id}</span>
+            <Stepper.List>
+              {stepper.state.all.map((step) => (
+                <Stepper.Item key={step.id} step={step.id}>
+                  <Stepper.Trigger
+                    onClick={(e) => {
+                      if (step.id === "second") e.preventDefault();
+                    }}
+                  >
+                    {step.title}
+                  </Stepper.Trigger>
+                </Stepper.Item>
+              ))}
+            </Stepper.List>
+          </>
+        )}
+      </Stepper.Root>,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Second" }));
+    expect(screen.getByTestId("current").textContent).toBe("first");
+  });
+
+  it("Stepper.Next and Stepper.Prev respect preventDefault in onClick", () => {
+    const { Stepper } = defineStepper(...steps);
+
+    render(
+      <Stepper.Root initialStep="second">
+        {({ stepper }) => (
+          <>
+            <span data-testid="current">{stepper.state.current.data.id}</span>
+            <Stepper.Prev onClick={(e) => e.preventDefault()}>Prev</Stepper.Prev>
+            <Stepper.Next onClick={(e) => e.preventDefault()}>Next</Stepper.Next>
+          </>
+        )}
+      </Stepper.Root>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Prev" }));
+    expect(screen.getByTestId("current").textContent).toBe("second");
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByTestId("current").textContent).toBe("second");
+  });
+
+  it("Stepper.List respects preventDefault in onKeyDown", () => {
+    const { Stepper } = defineStepper(...steps);
+
+    render(
+      <Stepper.Root>
+        {({ stepper }) => (
+          <>
+            <span data-testid="current">{stepper.state.current.data.id}</span>
+            <Stepper.List onKeyDown={(e) => e.preventDefault()}>
+              {stepper.state.all.map((step) => (
+                <Stepper.Item key={step.id} step={step.id}>
+                  <Stepper.Trigger>{step.title}</Stepper.Trigger>
+                </Stepper.Item>
+              ))}
+            </Stepper.List>
+          </>
+        )}
+      </Stepper.Root>,
+    );
+
+    const firstTrigger = screen.getByRole("tab", { name: "First" });
+    firstTrigger.focus();
+    fireEvent.keyDown(firstTrigger, { key: "ArrowRight" });
+
+    expect(screen.getByTestId("current").textContent).toBe("first");
+  });
+});

--- a/packages/react/src/tests/utils.test.ts
+++ b/packages/react/src/tests/utils.test.ts
@@ -2,27 +2,27 @@ import { describe, expect, it } from "vitest";
 import { getStatuses } from "../utils";
 
 const steps = [
-	{ id: "first", label: "Step 1" },
-	{ id: "second", label: "Step 2" },
-	{ id: "third", label: "Step 3" },
+  { id: "first", label: "Step 1" },
+  { id: "second", label: "Step 2" },
+  { id: "third", label: "Step 3" },
 ];
 
 describe("getStatuses", () => {
-	it("returns active for current index, success for past, inactive for future", () => {
-		expect(getStatuses(steps, 0)).toEqual({
-			first: "active",
-			second: "inactive",
-			third: "inactive",
-		});
-		expect(getStatuses(steps, 1)).toEqual({
-			first: "success",
-			second: "active",
-			third: "inactive",
-		});
-		expect(getStatuses(steps, 2)).toEqual({
-			first: "success",
-			second: "success",
-			third: "active",
-		});
-	});
+  it("returns active for current index, success for past, inactive for future", () => {
+    expect(getStatuses(steps, 0)).toEqual({
+      first: "active",
+      second: "inactive",
+      third: "inactive",
+    });
+    expect(getStatuses(steps, 1)).toEqual({
+      first: "success",
+      second: "active",
+      third: "inactive",
+    });
+    expect(getStatuses(steps, 2)).toEqual({
+      first: "success",
+      second: "success",
+      third: "active",
+    });
+  });
 });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,56 +1,56 @@
-import type { Get, Metadata, Step, Stepper, Utils } from "@stepperize/core";
+import type { Get, Metadata, Step, Stepper } from "@stepperize/core";
 import type { StepperPrimitives } from "./primitives/create-stepper-primitives";
 import type { StepStatus } from "./primitives/types";
 
 export type TransitionDirection = "next" | "prev" | "goTo";
 
 export type TransitionContext<Steps extends Step[]> = {
-	readonly from: Steps[number];
-	readonly to: Steps[number];
-	readonly metadata: Record<Get.Id<Steps>, Metadata>;
-	readonly statuses: Record<Get.Id<Steps>, StepStatus>;
-	readonly direction: TransitionDirection;
-	readonly fromIndex: number;
-	readonly toIndex: number;
+  readonly from: Steps[number];
+  readonly to: Steps[number];
+  readonly metadata: Record<Get.Id<Steps>, Metadata>;
+  readonly statuses: Record<Get.Id<Steps>, StepStatus>;
+  readonly direction: TransitionDirection;
+  readonly fromIndex: number;
+  readonly toIndex: number;
 };
 
 export type ScopedProps<Steps extends Step[]> = React.PropsWithChildren<{
-	/** The initial step to display. */
-	initialStep?: Get.Id<Steps>;
-	/** The initial metadata. */
-	initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+  /** The initial step to display. */
+  initialStep?: Get.Id<Steps>;
+  /** The initial metadata. */
+  initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
 }>;
 
 export type StepperReturn<Steps extends Step[]> = {
-	/** The steps of the stepper. */
-	steps: Steps;
-	/**
-	 * `Scoped` component is a wrapper that provides the stepper context to its children.
-	 * It uses the `Context` to pass the stepper instance to the children.
-	 *
-	 * @param props - The props object containing `initialStep` and `children`.
-	 * @param props.initialStep - The ID of the step to start with (optional).
-	 * @param props.initialMetadata - The initial metadata (optional).
-	 * @param props.children - The child elements to be wrapped by the `Scoped` component.
-	 * @returns A React element that wraps the children with the stepper context.
-	 */
-	Scoped: (props: ScopedProps<Steps>) => React.ReactElement;
-	/**
-	 * `useStepper` hook returns an object that manages the current step in the stepper.
-	 * You can use this hook to get the current step, navigate to the next or previous step,
-	 * and reset the stepper to the initial state.
-	 *
-	 * @param initialStep - The ID of the step to start with (optional).
-	 * @param initialMetadata - The initial metadata (optional).
-	 * @returns An object containing properties and methods to interact with the stepper.
-	 */
-	useStepper: (props?: {
-		initialStep?: Get.Id<Steps>;
-		initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
-	}) => Stepper<Steps>;
-	/**
-	 * Type-safe primitive components (Root, List, Item, Trigger, Title, Description, Indicator, Separator, Content, Actions, Prev, Next).
-	 * Use within Scoped. Root children can be a function receiving `{ stepper }`.
-	 */
-	Stepper: StepperPrimitives<Steps>;
+  /** The steps of the stepper. */
+  steps: Steps;
+  /**
+   * `Scoped` component is a wrapper that provides the stepper context to its children.
+   * It uses the `Context` to pass the stepper instance to the children.
+   *
+   * @param props - The props object containing `initialStep` and `children`.
+   * @param props.initialStep - The ID of the step to start with (optional).
+   * @param props.initialMetadata - The initial metadata (optional).
+   * @param props.children - The child elements to be wrapped by the `Scoped` component.
+   * @returns A React element that wraps the children with the stepper context.
+   */
+  Scoped: (props: ScopedProps<Steps>) => React.ReactElement;
+  /**
+   * `useStepper` hook returns an object that manages the current step in the stepper.
+   * You can use this hook to get the current step, navigate to the next or previous step,
+   * and reset the stepper to the initial state.
+   *
+   * @param initialStep - The ID of the step to start with (optional).
+   * @param initialMetadata - The initial metadata (optional).
+   * @returns An object containing properties and methods to interact with the stepper.
+   */
+  useStepper: (props?: {
+    initialStep?: Get.Id<Steps>;
+    initialMetadata?: Partial<Record<Get.Id<Steps>, Metadata>>;
+  }) => Stepper<Steps>;
+  /**
+   * Type-safe primitive components (Root, List, Item, Trigger, Title, Description, Indicator, Separator, Content, Actions, Prev, Next).
+   * Use within Scoped. Root children can be a function receiving `{ stepper }`.
+   */
+  Stepper: StepperPrimitives<Steps>;
 };

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,5 +1,5 @@
-import { Get, Step } from "@stepperize/core";
-import { StepStatus } from "./primitives/types";
+import type { Get, Step } from "@stepperize/core";
+import type { StepStatus } from "./primitives/types";
 
 export function getStatuses<Steps extends Step[]>(
   steps: Steps,
@@ -8,7 +8,11 @@ export function getStatuses<Steps extends Step[]>(
   return steps.reduce(
     (acc, step, i) => {
       acc[step.id as Get.Id<Steps>] =
-        i < currentIndex ? "success" : i === currentIndex ? "active" : "inactive";
+        i < currentIndex
+          ? "success"
+          : i === currentIndex
+            ? "active"
+            : "inactive";
       return acc;
     },
     {} as Record<Get.Id<Steps>, StepStatus>,

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -13,9 +13,14 @@ export default defineConfig({
   tsconfig: "tsconfig.json",
   terserOptions: {
     compress: {
+      module: true,
+      passes: 3,
+      pure_getters: true,
       drop_console: true,
       pure_funcs: ["console.info", "console.debug"],
     },
-    mangle: true,
+    mangle: {
+      toplevel: true,
+    },
   },
 });

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,21 +1,21 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: ["src/index.ts", "src/primitives/index.ts"],
-	format: ["esm"],
-	dts: true,
-	sourcemap: false,
-	clean: true,
-	minify: "terser",
-	treeshake: true,
-	splitting: true,
-	external: ["react", "react-dom"],
-	tsconfig: "tsconfig.json",
-	terserOptions: {
-		compress: {
-			drop_console: true,
-			pure_funcs: ["console.info", "console.debug"],
-		},
-		mangle: true,
-	},
+  entry: ["src/index.ts", "src/primitives/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: false,
+  clean: true,
+  minify: "terser",
+  treeshake: true,
+  splitting: true,
+  external: ["react", "react-dom"],
+  tsconfig: "tsconfig.json",
+  terserOptions: {
+    compress: {
+      drop_console: true,
+      pure_funcs: ["console.info", "console.debug"],
+    },
+    mangle: true,
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,20 +13,20 @@ catalogs:
       specifier: ^16.3.2
       version: 16.3.2
     '@types/react':
-      specifier: ^19.2.8
-      version: 19.2.8
+      specifier: ^19.2.14
+      version: 19.2.14
     '@types/react-dom':
       specifier: ^19.2.3
       version: 19.2.3
     jsdom:
-      specifier: ^27.4.0
-      version: 27.4.0
+      specifier: ^28.1.0
+      version: 28.1.0
     react:
-      specifier: ^19.2.3
-      version: 19.2.3
+      specifier: ^19.2.4
+      version: 19.2.4
     react-dom:
-      specifier: ^19.2.3
-      version: 19.2.3
+      specifier: ^19.2.4
+      version: 19.2.4
     terser:
       specifier: ^5.46.0
       version: 5.46.0
@@ -37,16 +37,16 @@ catalogs:
       specifier: ^5.9.3
       version: 5.9.3
     vitest:
-      specifier: ^4.0.17
-      version: 4.0.17
+      specifier: ^4.0.18
+      version: 4.0.18
 
 importers:
 
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.13
-        version: 2.3.13
+        specifier: 2.4.2
+        version: 2.4.2
       '@changesets/changelog-github':
         specifier: 0.5.2
         version: 0.5.2
@@ -54,8 +54,8 @@ importers:
         specifier: ^2.29.8
         version: 2.29.8(@types/node@25.0.9)
       turbo:
-        specifier: 2.8.0
-        version: 2.8.0
+        specifier: 2.8.10
+        version: 2.8.10
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -64,16 +64,16 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: ^1.1.0
-        version: 1.1.0(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@conform-to/react':
         specifier: ^1.16.0
-        version: 1.16.0(react@19.2.3)
+        version: 1.16.0(react@19.2.4)
       '@conform-to/zod':
         specifier: ^1.16.0
         version: 1.16.0(zod@4.3.5)
       '@hookform/resolvers':
         specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
+        version: 5.2.2(react-hook-form@7.71.1(react@19.2.4))
       '@radix-ui/colors':
         specifier: ^3.0.0
         version: 3.0.0
@@ -85,7 +85,7 @@ importers:
         version: link:../../packages/react
       '@tanstack/react-form':
         specifier: ^1.28.0
-        version: 1.28.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.28.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       arktype:
         specifier: ^2.1.29
         version: 2.1.29
@@ -97,46 +97,46 @@ importers:
         version: 2.1.1
       fumadocs-core:
         specifier: 16.4.7
-        version: 16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
+        version: 16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0))
+        version: 14.2.6(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0))
       fumadocs-twoslash:
         specifier: 3.1.12
-        version: 3.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 3.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       fumadocs-typescript:
         specifier: 5.0.1
-        version: 5.0.1(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18))(react@19.2.3)(typescript@5.9.3)
+        version: 5.0.1(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18))(react@19.2.4)(typescript@5.9.3)
       fumadocs-ui:
         specifier: 16.4.7
-        version: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)
+        version: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       geist:
         specifier: 1.5.1
-        version: 1.5.1(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 1.5.1(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
       lucide-react:
         specifier: ^0.562.0
-        version: 0.562.0(react@19.2.3)
+        version: 0.562.0(react@19.2.4)
       motion:
         specifier: ^12.27.1
-        version: 12.27.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 12.27.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       radix-ui:
         specifier: ^1.4.3
-        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 'catalog:'
-        version: 19.2.3
+        version: 19.2.4
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.3(react@19.2.3)
+        version: 19.2.4(react@19.2.4)
       react-hook-form:
         specifier: ^7.71.1
-        version: 7.71.1(react@19.2.3)
+        version: 7.71.1(react@19.2.4)
       shadcn:
         specifier: 3.7.0
         version: 3.7.0(@types/node@25.0.9)(hono@4.11.4)(typescript@5.9.3)
@@ -176,10 +176,10 @@ importers:
         version: 25.0.9
       '@types/react':
         specifier: 'catalog:'
-        version: 19.2.8
+        version: 19.2.14
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.2.3(@types/react@19.2.8)
+        version: 19.2.3(@types/react@19.2.14)
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
@@ -200,10 +200,10 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       jsdom:
         specifier: 'catalog:'
-        version: 27.4.0(@noble/hashes@1.8.0)
+        version: 28.1.0(@noble/hashes@1.8.0)
       terser:
         specifier: 'catalog:'
         version: 5.46.0
@@ -215,7 +215,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.17(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.5.0)
+        version: 4.0.18(@types/node@25.0.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.5.0)
 
   packages/react:
     dependencies:
@@ -228,16 +228,16 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: 'catalog:'
-        version: 19.2.8
+        version: 19.2.14
       jsdom:
         specifier: 'catalog:'
-        version: 27.4.0(@noble/hashes@1.8.0)
+        version: 28.1.0(@noble/hashes@1.8.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.3
+        version: 19.2.4
       terser:
         specifier: 'catalog:'
         version: 5.46.0
@@ -249,7 +249,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.17(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.5.0)
+        version: 4.0.18(@types/node@25.0.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.5.0)
 
 packages:
 
@@ -273,11 +273,11 @@ packages:
   '@ark/util@0.56.0':
     resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
-  '@asamuzakjp/css-color@4.1.1':
-    resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
 
-  '@asamuzakjp/dom-selector@6.7.6':
-    resolution: {integrity: sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==}
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
@@ -436,58 +436,62 @@ packages:
       '@types/react':
         optional: true
 
-  '@biomejs/biome@2.3.13':
-    resolution: {integrity: sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==}
+  '@biomejs/biome@2.4.2':
+    resolution: {integrity: sha512-vVE/FqLxNLbvYnFDYg3Xfrh1UdFhmPT5i+yPT9GE2nTUgI4rkqo5krw5wK19YHBd7aE7J6r91RRmb8RWwkjy6w==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.13':
-    resolution: {integrity: sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==}
+  '@biomejs/cli-darwin-arm64@2.4.2':
+    resolution: {integrity: sha512-3pEcKCP/1POKyaZZhXcxFl3+d9njmeAihZ17k8lL/1vk+6e0Cbf0yPzKItFiT+5Yh6TQA4uKvnlqe0oVZwRxCA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.13':
-    resolution: {integrity: sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==}
+  '@biomejs/cli-darwin-x64@2.4.2':
+    resolution: {integrity: sha512-P7hK1jLVny+0R9UwyGcECxO6sjETxfPyBm/1dmFjnDOHgdDPjPqozByunrwh4xPKld8sxOr5eAsSqal5uKgeBg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.13':
-    resolution: {integrity: sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.2':
+    resolution: {integrity: sha512-/x04YK9+7erw6tYEcJv9WXoBHcULI/wMOvNdAyE9S3JStZZ9yJyV67sWAI+90UHuDo/BDhq0d96LDqGlSVv7WA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.3.13':
-    resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
+  '@biomejs/cli-linux-arm64@2.4.2':
+    resolution: {integrity: sha512-DI3Mi7GT2zYNgUTDEbSjl3e1KhoP76OjQdm8JpvZYZWtVDRyLd3w8llSr2TWk1z+U3P44kUBWY3X7H9MD1/DGQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.3.13':
-    resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
+  '@biomejs/cli-linux-x64-musl@2.4.2':
+    resolution: {integrity: sha512-wbBmTkeAoAYbOQ33f6sfKG7pcRSydQiF+dTYOBjJsnXO2mWEOQHllKlC2YVnedqZFERp2WZhFUoO7TNRwnwEHQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.3.13':
-    resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
+  '@biomejs/cli-linux-x64@2.4.2':
+    resolution: {integrity: sha512-GK2ErnrKpWFigYP68cXiCHK4RTL4IUWhK92AFS3U28X/nuAL5+hTuy6hyobc8JZRSt+upXt1nXChK+tuHHx4mA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.3.13':
-    resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
+  '@biomejs/cli-win32-arm64@2.4.2':
+    resolution: {integrity: sha512-k2uqwLYrNNxnaoiW3RJxoMGnbKda8FuCmtYG3cOtVljs3CzWxaTR+AoXwKGHscC9thax9R4kOrtWqWN0+KdPTw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.13':
-    resolution: {integrity: sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==}
+  '@biomejs/cli-win32-x64@2.4.2':
+    resolution: {integrity: sha512-9ma7C4g8Sq3cBlRJD2yrsHXB1mnnEBdpy7PhvFrylQWQb4PoyCmPucdX7frvsSBQuFtIiKCrolPl/8tCZrKvgQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@changesets/apply-release-plan@7.0.14':
     resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
@@ -569,37 +573,36 @@ packages:
     peerDependencies:
       zod: ^3.21.0 || ^4.0.0
 
-  '@csstools/color-helpers@5.1.0':
-    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
-    engines: {node: '>=18'}
+  '@csstools/color-helpers@6.0.1':
+    resolution: {integrity: sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==}
+    engines: {node: '>=20.19.0'}
 
-  '@csstools/css-calc@2.1.4':
-    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
-    engines: {node: '>=18'}
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@3.1.0':
-    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
-    engines: {node: '>=18'}
+  '@csstools/css-color-parser@4.0.1':
+    resolution: {integrity: sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-parser-algorithms@3.0.5':
-    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
-    engines: {node: '>=18'}
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.25':
-    resolution: {integrity: sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==}
-    engines: {node: '>=18'}
+  '@csstools/css-syntax-patches-for-csstree@1.0.27':
+    resolution: {integrity: sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==}
 
-  '@csstools/css-tokenizer@3.0.4':
-    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
-    engines: {node: '>=18'}
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dotenvx/dotenvx@1.51.4':
     resolution: {integrity: sha512-AoziS8lRQ3ew/lY5J4JSlzYSN9Fo0oiyMBY37L3Bwq4mOQJT5GSrdZYLFPt6pH1LApDI3ZJceNyx+rHRACZSeQ==}
@@ -776,8 +779,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@exodus/bytes@1.9.0':
-    resolution: {integrity: sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==}
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       '@noble/hashes': ^1.8.0 || ^2.0.0
@@ -2453,8 +2456,8 @@ packages:
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
-  '@types/react@19.2.8':
-    resolution: {integrity: sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==}
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
@@ -2476,11 +2479,11 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@vitest/expect@4.0.17':
-    resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
-  '@vitest/mocker@4.0.17':
-    resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -2490,20 +2493,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.17':
-    resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
-  '@vitest/runner@4.0.17':
-    resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
-  '@vitest/snapshot@4.0.17':
-    resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
-  '@vitest/spy@4.0.17':
-    resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
 
-  '@vitest/utils@4.0.17':
-    resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2820,8 +2823,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  cssstyle@5.3.7:
-    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+  cssstyle@6.0.1:
+    resolution: {integrity: sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==}
     engines: {node: '>=20'}
 
   csstype@3.2.3:
@@ -2831,9 +2834,9 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  data-urls@6.0.0:
-    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
-    engines: {node: '>=20'}
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -3556,8 +3559,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@27.4.0:
-    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
@@ -3693,8 +3696,8 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
-  lru-cache@11.2.4:
-    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -4293,10 +4296,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@19.2.3:
-    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
-      react: ^19.2.3
+      react: ^19.2.4
 
   react-hook-form@7.71.1:
     resolution: {integrity: sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==}
@@ -4343,8 +4346,8 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.2.3:
-    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -4774,38 +4777,38 @@ packages:
       typescript:
         optional: true
 
-  turbo-darwin-64@2.8.0:
-    resolution: {integrity: sha512-N7f4PYqz25yk8c5kituk09bJ89tE4wPPqKXgYccT6nbEQnGnrdvlyCHLyqViNObTgjjrddqjb1hmDkv7VcxE0g==}
+  turbo-darwin-64@2.8.10:
+    resolution: {integrity: sha512-A03fXh+B7S8mL3PbdhTd+0UsaGrhfyPkODvzBDpKRY7bbeac4MDFpJ7I+Slf2oSkCEeSvHKR7Z4U71uKRUfX7g==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.8.0:
-    resolution: {integrity: sha512-eVzejaP5fn51gmJAPW68U6mSjFaAZ26rPiE36mMdk+tMC4XBGmJHT/fIgrhcrXMvINCl27RF8VmguRe+MBlSuQ==}
+  turbo-darwin-arm64@2.8.10:
+    resolution: {integrity: sha512-sidzowgWL3s5xCHLeqwC9M3s9M0i16W1nuQF3Mc7fPHpZ+YPohvcbVFBB2uoRRHYZg6yBnwD4gyUHKTeXfwtXA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.8.0:
-    resolution: {integrity: sha512-ILR45zviYae3icf4cmUISdj8X17ybNcMh3Ms4cRdJF5sS50qDDTv8qeWqO/lPeHsu6r43gVWDofbDZYVuXYL7Q==}
+  turbo-linux-64@2.8.10:
+    resolution: {integrity: sha512-YK9vcpL3TVtqonB021XwgaQhY9hJJbKKUhLv16osxV0HkcQASQWUqR56yMge7puh6nxU67rQlTq1b7ksR1T3KA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.8.0:
-    resolution: {integrity: sha512-z9pUa8ENFuHmadPfjEYMRWlXO82t1F/XBDx2XTg+cWWRZHf85FnEB6D4ForJn/GoKEEvwdPhFLzvvhOssom2ug==}
+  turbo-linux-arm64@2.8.10:
+    resolution: {integrity: sha512-3+j2tL0sG95iBJTm+6J8/45JsETQABPqtFyYjVjBbi6eVGdtNTiBmHNKrbvXRlQ3ZbUG75bKLaSSDHSEEN+btQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.8.0:
-    resolution: {integrity: sha512-J6juRSRjmSErEqJCv7nVIq2DgZ2NHXqyeV8NQTFSyIvrThKiWe7FDOO6oYpuR06+C1NW82aoN4qQt4/gYvz25w==}
+  turbo-windows-64@2.8.10:
+    resolution: {integrity: sha512-hdeF5qmVY/NFgiucf8FW0CWJWtyT2QPm5mIsX0W1DXAVzqKVXGq+Zf+dg4EUngAFKjDzoBeN6ec2Fhajwfztkw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.8.0:
-    resolution: {integrity: sha512-qarBZvCu6uka35739TS+y/3CBU3zScrVAfohAkKHG+So+93Wn+5tKArs8HrO2fuTaGou8fMIeTV7V5NgzCVkSQ==}
+  turbo-windows-arm64@2.8.10:
+    resolution: {integrity: sha512-QGdr/Q8LWmj+ITMkSvfiz2glf0d7JG0oXVzGL3jxkGqiBI1zXFj20oqVY0qWi+112LO9SVrYdpHS0E/oGFrMbQ==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.8.0:
-    resolution: {integrity: sha512-hYbxnLEdvJF+DLALS+Ia+PbfNtn0sDP0hH2u9AFoskSUDmcVHSrtwHpzdX94MrRJKo9D9tYxY3MyP20gnlrWyA==}
+  turbo@2.8.10:
+    resolution: {integrity: sha512-OxbzDES66+x7nnKGg2MwBA1ypVsZoDTLHpeaP4giyiHSixbsiTaMyeJqbEyvBdp5Cm28fc+8GG6RdQtic0ijwQ==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -4837,6 +4840,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -4977,18 +4984,18 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.17:
-    resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.17
-      '@vitest/browser-preview': 4.0.17
-      '@vitest/browser-webdriverio': 4.0.17
-      '@vitest/ui': 4.0.17
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5026,13 +5033,13 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  whatwg-mimetype@4.0.0:
-    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
-    engines: {node: '>=18'}
-
-  whatwg-url@15.1.0:
-    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5062,18 +5069,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -5149,21 +5144,21 @@ snapshots:
 
   '@ark/util@0.56.0': {}
 
-  '@asamuzakjp/css-color@4.1.1':
+  '@asamuzakjp/css-color@4.1.2':
     dependencies:
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.4
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
 
-  '@asamuzakjp/dom-selector@6.7.6':
+  '@asamuzakjp/dom-selector@6.8.1':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.4
+      lru-cache: 11.2.6
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
@@ -5355,65 +5350,69 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.1.0(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@base-ui/react@1.1.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@base-ui/utils': 0.2.4(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@base-ui/utils': 0.2.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/utils': 0.2.10
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
       reselect: 5.1.1
       tabbable: 6.4.0
-      use-sync-external-store: 1.6.0(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@base-ui/utils@0.2.4(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@base-ui/utils@0.2.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@floating-ui/utils': 0.2.10
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
       reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@biomejs/biome@2.3.13':
+  '@biomejs/biome@2.4.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.13
-      '@biomejs/cli-darwin-x64': 2.3.13
-      '@biomejs/cli-linux-arm64': 2.3.13
-      '@biomejs/cli-linux-arm64-musl': 2.3.13
-      '@biomejs/cli-linux-x64': 2.3.13
-      '@biomejs/cli-linux-x64-musl': 2.3.13
-      '@biomejs/cli-win32-arm64': 2.3.13
-      '@biomejs/cli-win32-x64': 2.3.13
+      '@biomejs/cli-darwin-arm64': 2.4.2
+      '@biomejs/cli-darwin-x64': 2.4.2
+      '@biomejs/cli-linux-arm64': 2.4.2
+      '@biomejs/cli-linux-arm64-musl': 2.4.2
+      '@biomejs/cli-linux-x64': 2.4.2
+      '@biomejs/cli-linux-x64-musl': 2.4.2
+      '@biomejs/cli-win32-arm64': 2.4.2
+      '@biomejs/cli-win32-x64': 2.4.2
 
-  '@biomejs/cli-darwin-arm64@2.3.13':
+  '@biomejs/cli-darwin-arm64@2.4.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.13':
+  '@biomejs/cli-darwin-x64@2.4.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.13':
+  '@biomejs/cli-linux-arm64-musl@2.4.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.13':
+  '@biomejs/cli-linux-arm64@2.4.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.13':
+  '@biomejs/cli-linux-x64-musl@2.4.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.13':
+  '@biomejs/cli-linux-x64@2.4.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.13':
+  '@biomejs/cli-win32-arm64@2.4.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.13':
+  '@biomejs/cli-win32-x64@2.4.2':
     optional: true
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.1.0
 
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
@@ -5587,37 +5586,37 @@ snapshots:
 
   '@conform-to/dom@1.16.0': {}
 
-  '@conform-to/react@1.16.0(react@19.2.3)':
+  '@conform-to/react@1.16.0(react@19.2.4)':
     dependencies:
       '@conform-to/dom': 1.16.0
-      react: 19.2.3
+      react: 19.2.4
 
   '@conform-to/zod@1.16.0(zod@4.3.5)':
     dependencies:
       '@conform-to/dom': 1.16.0
       zod: 4.3.5
 
-  '@csstools/color-helpers@5.1.0': {}
+  '@csstools/color-helpers@6.0.1': {}
 
-  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-color-parser@4.0.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 5.1.0
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/color-helpers': 6.0.1
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
+  '@csstools/css-syntax-patches-for-csstree@1.0.27': {}
 
-  '@csstools/css-tokenizer@3.0.4': {}
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dotenvx/dotenvx@1.51.4':
     dependencies:
@@ -5729,7 +5728,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@exodus/bytes@1.9.0(@noble/hashes@1.8.0)':
+  '@exodus/bytes@1.14.1(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
@@ -5742,11 +5741,11 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@floating-ui/react-dom@2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
 
@@ -5771,27 +5770,27 @@ snapshots:
       tinyexec: 1.0.2
       zod: 4.3.5
 
-  '@fumadocs/ui@16.4.7(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.7(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
-      next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      fumadocs-core: 16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
+      next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
       tailwind-merge: 3.4.0
     optionalDependencies:
-      '@types/react': 19.2.8
-      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/react': 19.2.14
+      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:
       hono: 4.11.4
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.3))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.4))':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.71.1(react@19.2.3)
+      react-hook-form: 7.71.1(react@19.2.4)
 
   '@img/colour@1.0.0':
     optional: true
@@ -6228,753 +6227,753 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.8)(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.8
-
-  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      react: 19.2.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.8)(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.8
-
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.8)(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.8
-
-  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/rect': 1.1.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      react: 19.2.3
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.6.0(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.2.3
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.1': {}
 
@@ -7200,20 +7199,20 @@ snapshots:
 
   '@tanstack/pacer-lite@0.1.1': {}
 
-  '@tanstack/react-form@1.28.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-form@1.28.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/form-core': 1.28.0
-      '@tanstack/react-store': 0.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
+      '@tanstack/react-store': 0.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
     transitivePeerDependencies:
       - react-dom
 
-  '@tanstack/react-store@0.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-store@0.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/store': 0.8.0
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      use-sync-external-store: 1.6.0(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   '@tanstack/store@0.7.7': {}
 
@@ -7239,15 +7238,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -7303,15 +7302,15 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/react-dom@19.2.3(@types/react@19.2.8)':
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  '@types/react@19.2.8':
+  '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 
@@ -7332,44 +7331,44 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/expect@4.0.17':
+  '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.17
-      '@vitest/utils': 4.0.17
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0))':
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0))':
     dependencies:
-      '@vitest/spy': 4.0.17
+      '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@25.0.9)(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0)
 
-  '@vitest/pretty-format@4.0.17':
+  '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.17':
+  '@vitest/runner@4.0.18':
     dependencies:
-      '@vitest/utils': 4.0.17
+      '@vitest/utils': 4.0.18
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.17':
+  '@vitest/snapshot@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 4.0.17
+      '@vitest/pretty-format': 4.0.18
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.17': {}
+  '@vitest/spy@4.0.18': {}
 
-  '@vitest/utils@4.0.17':
+  '@vitest/utils@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 4.0.17
+      '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
   accepts@2.0.0:
@@ -7630,21 +7629,23 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssstyle@5.3.7:
+  cssstyle@6.0.1:
     dependencies:
-      '@asamuzakjp/css-color': 4.1.1
-      '@csstools/css-syntax-patches-for-csstree': 1.0.25
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.0.27
       css-tree: 3.1.0
-      lru-cache: 11.2.4
+      lru-cache: 11.2.6
 
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-urls@6.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 15.1.0
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   dataloader@1.4.0: {}
 
@@ -7977,14 +7978,14 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.27.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  framer-motion@12.27.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       motion-dom: 12.27.1
       motion-utils: 12.24.10
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   fresh@2.0.0: {}
 
@@ -8009,7 +8010,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5):
+  fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5):
     dependencies:
       '@formatjs/intl-localematcher': 0.7.5
       '@orama/orama': 3.1.18
@@ -8031,23 +8032,23 @@ snapshots:
       tinyglobby: 0.2.15
       unist-util-visit: 5.0.0
     optionalDependencies:
-      '@types/react': 19.2.8
-      lucide-react: 0.562.0(react@19.2.3)
-      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@types/react': 19.2.14
+      lucide-react: 0.562.0(react@19.2.4)
+      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
       zod: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0)):
+  fumadocs-mdx@14.2.6(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
+      fumadocs-core: 16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
       js-yaml: 4.1.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -8061,40 +8062,40 @@ snapshots:
       vfile: 6.0.3
       zod: 4.3.5
     optionalDependencies:
-      '@types/react': 19.2.8
-      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
+      '@types/react': 19.2.14
+      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
       vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  fumadocs-twoslash@3.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@shikijs/twoslash': 3.21.0(typescript@5.9.3)
-      fumadocs-ui: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)
+      fumadocs-ui: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
-      react: 19.2.3
+      react: 19.2.4
       shiki: 3.21.0
       tailwind-merge: 3.4.0
       twoslash: 0.3.6(typescript@5.9.3)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
       - supports-color
       - typescript
 
-  fumadocs-typescript@5.0.1(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18))(react@19.2.3)(typescript@5.9.3):
+  fumadocs-typescript@5.0.1(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
+      fumadocs-core: 16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
-      react: 19.2.3
+      react: 19.2.4
       remark: 15.0.1
       remark-rehype: 11.1.2
       tinyglobby: 0.2.15
@@ -8102,35 +8103,35 @@ snapshots:
       typescript: 5.9.3
       unist-util-visit: 5.0.0
     optionalDependencies:
-      '@types/react': 19.2.8
-      fumadocs-ui: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)
+      '@types/react': 19.2.14
+      fumadocs-ui: 16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.7(@types/react@19.2.8)(fumadocs-core@16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)
-      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@fumadocs/ui': 16.4.7(@types/react@19.2.14)(fumadocs-core@16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.7(@types/react@19.2.8)(lucide-react@0.562.0(react@19.2.3))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.3.5)
-      lucide-react: 0.562.0(react@19.2.3)
-      next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-medium-image-zoom: 5.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      fumadocs-core: 16.4.7(@types/react@19.2.14)(lucide-react@0.562.0(react@19.2.4))(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.5)
+      lucide-react: 0.562.0(react@19.2.4)
+      next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-medium-image-zoom: 5.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
-      '@types/react': 19.2.8
-      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/react': 19.2.14
+      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -8141,9 +8142,9 @@ snapshots:
 
   fzf@0.5.2: {}
 
-  geist@1.5.1(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  geist@1.5.1(next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   gensync@1.0.0-beta.2: {}
 
@@ -8276,7 +8277,7 @@ snapshots:
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.9.0(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -8415,13 +8416,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.4.0(@noble/hashes@1.8.0):
+  jsdom@28.1.0(@noble/hashes@1.8.0):
     dependencies:
       '@acemir/cssom': 0.9.31
-      '@asamuzakjp/dom-selector': 6.7.6
-      '@exodus/bytes': 1.9.0(@noble/hashes@1.8.0)
-      cssstyle: 5.3.7
-      data-urls: 6.0.0
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
+      cssstyle: 6.0.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       http-proxy-agent: 7.0.2
@@ -8431,17 +8433,15 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
+      undici: 7.22.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 15.1.0
-      ws: 8.19.0
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -8535,15 +8535,15 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
-  lru-cache@11.2.4: {}
+  lru-cache@11.2.6: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.562.0(react@19.2.3):
+  lucide-react@0.562.0(react@19.2.4):
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
 
   lz-string@1.5.0: {}
 
@@ -9030,13 +9030,13 @@ snapshots:
 
   motion-utils@12.24.10: {}
 
-  motion@12.27.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  motion@12.27.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      framer-motion: 12.27.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      framer-motion: 12.27.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   mri@1.2.0: {}
 
@@ -9079,21 +9079,21 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.15
       caniuse-lite: 1.0.30001765
       postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.3
       '@next/swc-darwin-x64': 16.1.3
@@ -9384,68 +9384,68 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   range-parser@1.2.1: {}
 
@@ -9456,50 +9456,50 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-dom@19.2.3(react@19.2.3):
+  react-dom@19.2.4(react@19.2.4):
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
       scheduler: 0.27.0
 
-  react-hook-form@7.71.1(react@19.2.3):
+  react-hook-form@7.71.1(react@19.2.4):
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
 
   react-is@17.0.2: {}
 
-  react-medium-image-zoom@5.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-medium-image-zoom@5.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.8)(react@19.2.3):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      react: 19.2.3
-      react-style-singleton: 2.2.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  react-remove-scroll@2.7.2(@types/react@19.2.8)(react@19.2.3):
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      react: 19.2.3
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.8)(react@19.2.3)
-      react-style-singleton: 2.2.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.8)(react@19.2.3)
-      use-sidecar: 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  react-style-singleton@2.2.3(@types/react@19.2.8)(react@19.2.3):
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.3
+      react: 19.2.4
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  react@19.2.3: {}
+  react@19.2.4: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -9941,10 +9941,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.28.6)(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.6)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.3
+      react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.28.6
 
@@ -10078,32 +10078,32 @@ snapshots:
       - tsx
       - yaml
 
-  turbo-darwin-64@2.8.0:
+  turbo-darwin-64@2.8.10:
     optional: true
 
-  turbo-darwin-arm64@2.8.0:
+  turbo-darwin-arm64@2.8.10:
     optional: true
 
-  turbo-linux-64@2.8.0:
+  turbo-linux-64@2.8.10:
     optional: true
 
-  turbo-linux-arm64@2.8.0:
+  turbo-linux-arm64@2.8.10:
     optional: true
 
-  turbo-windows-64@2.8.0:
+  turbo-windows-64@2.8.10:
     optional: true
 
-  turbo-windows-arm64@2.8.0:
+  turbo-windows-arm64@2.8.10:
     optional: true
 
-  turbo@2.8.0:
+  turbo@2.8.10:
     optionalDependencies:
-      turbo-darwin-64: 2.8.0
-      turbo-darwin-arm64: 2.8.0
-      turbo-linux-64: 2.8.0
-      turbo-linux-arm64: 2.8.0
-      turbo-windows-64: 2.8.0
-      turbo-windows-arm64: 2.8.0
+      turbo-darwin-64: 2.8.10
+      turbo-darwin-arm64: 2.8.10
+      turbo-linux-64: 2.8.10
+      turbo-linux-arm64: 2.8.10
+      turbo-windows-64: 2.8.10
+      turbo-windows-arm64: 2.8.10
 
   tw-animate-css@1.4.0: {}
 
@@ -10132,6 +10132,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.22.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -10191,24 +10193,24 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.8)(react@19.2.3):
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  use-sidecar@1.1.3(@types/react@19.2.8)(react@19.2.3):
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.3
+      react: 19.2.4
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.8
+      '@types/react': 19.2.14
 
-  use-sync-external-store@1.6.0(react@19.2.3):
+  use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
-      react: 19.2.3
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 
@@ -10246,15 +10248,15 @@ snapshots:
       terser: 5.46.0
       yaml: 2.5.0
 
-  vitest@4.0.17(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.5.0):
+  vitest@4.0.18(@types/node@25.0.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.5.0):
     dependencies:
-      '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0))
-      '@vitest/pretty-format': 4.0.17
-      '@vitest/runner': 4.0.17
-      '@vitest/snapshot': 4.0.17
-      '@vitest/spy': 4.0.17
-      '@vitest/utils': 4.0.17
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.5.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10270,7 +10272,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.9
-      jsdom: 27.4.0(@noble/hashes@1.8.0)
+      jsdom: 28.1.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -10294,12 +10296,15 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  whatwg-mimetype@4.0.0: {}
+  whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@15.1.0:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
+      '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -10332,8 +10337,6 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
-
-  ws@8.19.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,14 +3,14 @@ packages:
   - packages/*
 
 catalog:
-  '@testing-library/jest-dom': ^6.9.1
-  '@testing-library/react': ^16.3.2
-  '@types/react': ^19.2.8
-  '@types/react-dom': ^19.2.3
-  jsdom: ^27.4.0
-  react: ^19.2.3
-  react-dom: ^19.2.3
+  "@testing-library/jest-dom": ^6.9.1
+  "@testing-library/react": ^16.3.2
+  "@types/react": ^19.2.14
+  "@types/react-dom": ^19.2.3
+  jsdom: ^28.1.0
+  react: ^19.2.4
+  react-dom: ^19.2.4
   terser: ^5.46.0
   tsup: ^8.5.1
   typescript: ^5.9.3
-  vitest: ^4.0.17
+  vitest: ^4.0.18


### PR DESCRIPTION
# Lifecycle: multiple callbacks + navigation payload (metadata)

## Summary

Addresses feedback from v6 adoption: (1) `onBeforeTransition` / `onAfterTransition` overwrote the previous handler, so Stepper-level and step-level logic couldn’t coexist; (2) setting metadata and then calling `next()` in the same handler left `ctx.metadata` stale in the transition hooks (setState is async). This PR adds **multiple lifecycle callbacks with unsubscribe** and **optional payload for `next` / `prev` / `goTo`** so metadata can be passed into the transition and persisted without relying on setState flushing.

---

## 1. Lifecycle: multiple callbacks + unsubscribe

### Before

- `stepper.lifecycle.onBeforeTransition(cb)` and `onAfterTransition(cb)` stored a **single** callback in a ref. Each call **overwrote** the previous one.
- No way to remove a handler; only replace it.
- If the Stepper registered a global handler (e.g. “confirm on prev”) and a step component registered its own (e.g. validation), only the **last** registered handler ran.

```tsx
// Stepper.tsx
function Stepper() {
  const stepper = useStepper();
  React.useEffect(() => {
    stepper.lifecycle.onBeforeTransition(async (ctx) => {
      if (ctx.direction === "prev" && !window.confirm("Go back?")) return false;
    });
  }, [stepper]);
  return (
    <>
      {stepper.flow.switch({
        "step-1": () => <Step1 />,
        "step-2": () => <Step2 />,
      })}
    </>
  );
}

// Step1.tsx — ❌ This overwrote the Stepper handler; "Go back?" confirm disappeared
function Step1() {
  const stepper = useStepper();
  React.useEffect(() => {
    stepper.lifecycle.onBeforeTransition(async (ctx) => {
      if (ctx.from.id === "step-1") await validateStep1();
    });
  }, [stepper]);
  return <button onClick={() => stepper.navigation.next()}>Next</button>;
}
```

### After

- Callbacks are stored in **arrays**. Each call **adds** a handler; all run in registration order.
- Each call returns an **unsubscribe** function; use it in `useEffect` cleanup to remove only that handler when the component unmounts.
- Stepper and step components can each register their own handler; **all run**. If any `onBeforeTransition` returns `false`, the transition is cancelled.

```tsx
// Stepper.tsx — same as before
function Stepper() {
  const stepper = useStepper();
  React.useEffect(() => {
    const unsub = stepper.lifecycle.onBeforeTransition(async (ctx) => {
      if (ctx.direction === "prev" && !window.confirm("Go back?")) return false;
    });
    return () => unsub();
  }, [stepper]);
  return (
    <>
      {stepper.flow.switch({
        "step-1": () => <Step1 />,
        "step-2": () => <Step2 />,
      })}
    </>
  );
}

// Step1.tsx — ✅ Adds its handler; both run. Unsubscribe on unmount.
function Step1() {
  const stepper = useStepper();
  React.useEffect(() => {
    const unsub = stepper.lifecycle.onBeforeTransition(async (ctx) => {
      if (ctx.from.id === "step-1") {
        const ok = await validateStep1();
        if (!ok) return false;
      }
    });
    return () => unsub();
  }, [stepper]);
  return <button onClick={() => stepper.navigation.next()}>Next</button>;
}
```

**API (core):**

- `onBeforeTransition(cb)` → returns `() => void` (unsubscribe).
- `onAfterTransition(cb)` → returns `() => void` (unsubscribe).

---

## 2. Navigation payload (metadata in transition)

### Before

- `next()`, `prev()`, `goTo(id)` had no payload. If you did `metadata.set("step-1", { url })` and then `next()` in the same click, `onBeforeTransition` / `onAfterTransition` received `ctx.metadata` from the **previous** React state (setState hadn’t flushed yet). So hooks saw **stale** metadata unless you moved the “set” logic inside the hook, which forced step-specific logic into a single global handler.

```tsx
function Step1() {
  const stepper = useStepper();
  const generateUrlAndNavigate = async () => {
    const url = await generateUrl();
    stepper.metadata.set("step-1", { ...step1Meta, data: { url } });
    stepper.navigation.next();
  };
  return <button onClick={generateUrlAndNavigate}>Next</button>;
}

// In onBeforeTransition:
stepper.lifecycle.onBeforeTransition(async (ctx) => {
  const step1Data = ctx.metadata["step-1"]; // ❌ undefined or old value, no `url`
});
```

### After

- **`next(payload?)`**, **`prev(payload?)`**, **`goTo(id, payload?)`** accept an optional **`TransitionPayload<Steps>`** with `metadata?: Partial<Record<StepId, Metadata>>`.
- That metadata is **merged** into `ctx.metadata` for **that** transition and **persisted** (same as `metadata.set`). So the lifecycle hooks see up-to-date metadata without waiting for setState.
- Same payload shape for all three: `next`, `prev`, and `goTo`.

```tsx
function Step1() {
  const stepper = useStepper();
  const generateUrlAndNavigate = async () => {
    const url = await generateUrl();
    stepper.navigation.next({
      metadata: { "step-1": { ...step1Meta, data: { url } } },
    });
  };
  return <button onClick={generateUrlAndNavigate}>Next</button>;
}

// In onBeforeTransition:
stepper.lifecycle.onBeforeTransition(async (ctx) => {
  const step1Data = ctx.metadata["step-1"]; // ✅ includes data: { url }
});
```

**Examples for prev and goTo:**

```tsx
stepper.navigation.prev({ metadata: { "step-1": { reason: "back" } } });
stepper.navigation.goTo("summary", { metadata: { "payment": { method: "card" } } });
```

**API (core):**

- `TransitionPayload<Steps> = { metadata?: Partial<Record<Get.Id<Steps>, Metadata>> }`.
- `next(payload?: TransitionPayload<Steps>)`.
- `prev(payload?: TransitionPayload<Steps>)`.
- `goTo(id: Get.Id<Steps>, payload?: TransitionPayload<Steps>)`.

---

## 3. Implementation notes

- **packages/core**: New type `TransitionPayload`; `StepperNavigation` and `StepperLifecycle` updated as above; `TransitionPayload` exported.
- **packages/react**: Refs replaced with arrays of callbacks; `performTransition(from, to, direction, payload?)` builds `ctx.metadata` as `{ ...metadata, ...payload?.metadata }`, runs all before callbacks, persists payload metadata via `setMetadata`, then runs after callbacks. `hasLifecycle` is read at **call time** (not at memo time) so handlers registered in a later `useEffect` are seen.
- **Tests**: New tests for multiple `onBeforeTransition` callbacks (order + cancel), unsubscribe, and `next(payload)` merging and persisting metadata.
- **Docs**: hook.mdx, types.mdx, migrating-to-v6.mdx updated (multiple callbacks, unsubscribe, payload for next/prev/goTo, examples).

---

## 4. Breaking changes

- **None** for existing usage. Code that calls `onBeforeTransition` once keeps working (one handler, runs as before). Code that calls `next()` / `prev()` / `goTo()` without payload is unchanged. The only behavioral change is when **multiple** components register lifecycle callbacks: previously the last one won; now all run. That fixes the reported bug rather than breaking existing single-handler setups.

---

## 5. Checklist

- [x] Core types updated (`TransitionPayload`, navigation, lifecycle).
- [x] React implementation (callback arrays, payload in `performTransition`, `hasLifecycle()` at call time).
- [x] Tests added/updated (lifecycle multi-callback, unsubscribe, payload metadata).
- [x] Docs updated (hook, types, migration; examples for multiple callbacks, unsubscribe, next/prev/goTo payload).

## 6. Related issues
https://github.com/damianricobelli/stepperize/issues/164

Thanks @tmcdo1 for the feedback!